### PR TITLE
setup : add meteor testing packages - meteortesting:browser-tests meteortesting:mocha meteortesting:mocha-core

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -22,3 +22,6 @@ react-meteor-data       # React higher-order component for reactively tracking M
 aldeed:simple-schema
 aldeed:collection2
 communitypackages:react-router-ssr
+meteortesting:browser-tests
+meteortesting:mocha
+meteortesting:mocha-core


### PR DESCRIPTION
Fixes `meteor npm run start` removing:
```
meteortesting:browser-tests@1.7.0
meteortesting:mocha@3.2.0
meteortesting:mocha-core@8.2.0
```
where `meteor npm run test` adds them back each time