### PR TITLE
Downgrade to meteor 3.1.2

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -6,7 +6,7 @@
 
 meteor-base@1.5.2             # Packages every Meteor app needs to have
 mobile-experience@1.1.2       # Packages for a great mobile UX
-mongo@2.1.1                   # The database Meteor supports right now
+mongo@2.1.0                   # The database Meteor supports right now
 reactive-var@1.0.13            # Reactive variable for tracker
 
 standard-minifier-css@1.9.3   # CSS minifier run for production mode
@@ -22,8 +22,8 @@ react-meteor-data       # React higher-order component for reactively tracking M
 aldeed:simple-schema
 aldeed:collection2
 communitypackages:react-router-ssr
-accounts-base
-accounts-password
+accounts-base@3.0.4
+accounts-password@3.0.3
 meteortesting:browser-tests
 meteortesting:mocha
 meteortesting:mocha-core

--- a/.meteor/release
+++ b/.meteor/release
@@ -1,1 +1,1 @@
-METEOR@3.2
+METEOR@3.1.2

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -1,5 +1,5 @@
-accounts-base@3.1.0
-accounts-password@3.1.0
+accounts-base@3.0.4
+accounts-password@3.0.3
 aldeed:collection2@4.1.1
 aldeed:simple-schema@2.0.0
 allow-deny@2.1.0


### PR DESCRIPTION
Downgrades to Meteor v3.1.2 as a temporary workaround to 'node-gyp-build' issue on windows from accounts-password 