### PR TITLE
Clean up UI on create skilltree page and remove irrelvant links in nav bar

### DIFF
--- a/imports/ui/components/NavBar.jsx
+++ b/imports/ui/components/NavBar.jsx
@@ -134,18 +134,6 @@ export const NavBar = () => {
           Home
         </Link>
         <Link
-          to="/Sample"
-          className="text-white hover:bg-gray-600 px-3 py-2 rounded"
-        >
-          Sample
-        </Link>
-        <Link
-          to="/404"
-          className="text-white hover:bg-gray-600 px-3 py-2 rounded"
-        >
-          404
-        </Link>
-        <Link
           to="/pendingproofs"
           className="text-white hover:bg-gray-600 px-3 py-2 rounded"
         >

--- a/imports/ui/components/SkillTree.jsx
+++ b/imports/ui/components/SkillTree.jsx
@@ -15,6 +15,7 @@ import { NewEmptyNode } from './nodes/NewEmptyNode';
 import { ViewNode } from './nodes/ViewNode';
 import { SkillEditForm } from './SkillEditForm';
 import { SkillViewForm } from './SkillViewForm';
+import { Button } from 'flowbite-react';
 // This is the logic and page for creating/editing a skilltree
 
 const createNewEmptyNode = isEmpty => props => (
@@ -156,12 +157,28 @@ export const SkillTreeLogic = ({
 
   return (
     <>
-      <h2 className="text-4xl font-bold" style={{ color: '#328E6E' }}>
-        Add Skills
-      </h2>
-      {isAdmin && <button onClick={handleOnSave}>Save</button>}
+      {isAdmin ? (
+        <>
+          <h2 className="text-4xl font-bold" style={{ color: '#328E6E' }}>
+            Add Skills
+          </h2>
 
-      <div style={{ width: '100vw', height: '60vh' }} ref={reactFlowWrapper}>
+          <Button
+            pill
+            color="green"
+            className="focus:ring-0 w-32 font-bold text-md enabled:cursor-pointer"
+            onClick={handleOnSave}
+          >
+            Save
+          </Button>
+        </>
+      ) : (
+        <h2 className="text-4xl font-bold" style={{ color: '#328E6E' }}>
+          Skills
+        </h2>
+      )}
+
+      <div style={{ width: '100vw', height: '65vh' }} ref={reactFlowWrapper}>
         <ReactFlow
           nodes={nodes}
           nodeTypes={nodeTypes}
@@ -178,13 +195,18 @@ export const SkillTreeLogic = ({
           <Controls />
         </ReactFlow>
       </div>
-      <button
-        onClick={() => {
-          onBack(nodes, edges);
-        }}
-      >
-        Back
-      </button>
+      {isAdmin && (
+        <Button
+          pill
+          color="green"
+          className="focus:ring-0 w-32 font-bold text-md enabled:cursor-pointer"
+          onClick={() => {
+            onBack(nodes, edges);
+          }}
+        >
+          Back
+        </Button>
+      )}
       {/* Modal rendered outside ReactFlow */}
       {editingNode &&
         (isAdmin ? (


### PR DESCRIPTION
- Added styling for the `save` and `back` buttons
   - Only render them when the user is an admin (show on create skilltree page, hide on the normal community page)

- Also removed `sample page` and `404 page` from the nav bar