### PR TITLE
Fix skill tree not rendering proper skills when switching via search bar

### DIFF
--- a/imports/ui/components/SkillTree.jsx
+++ b/imports/ui/components/SkillTree.jsx
@@ -41,6 +41,20 @@ export const SkillTreeLogic = ({
   savedEdges,
   onBack
 }) => {
+  // Update nodes when props change after new search
+  useEffect(() => {
+    if (savedNodes?.length) {
+      setNodes(savedNodes);
+    }
+  }, [savedNodes]);
+
+  // Update edges when props change after new search
+  useEffect(() => {
+    if (savedEdges?.length) {
+      setEdges(savedEdges);
+    }
+  }, [savedEdges]);
+
   // Reattach OpenEditor handlers to nodes. They are lost when saved to DB
   const attachOpenEditorHandlers = (savedNodes = []) =>
     savedNodes.map(node => ({


### PR DESCRIPTION
- Fix skill tree not rendering proper skills when switching between communities via search bar