### PR TITLE
Fix issue with newly created posts being listed under 'my user' instead of the creator's username

### DIFF
--- a/imports/ui/components/ProofUploadButton.jsx
+++ b/imports/ui/components/ProofUploadButton.jsx
@@ -6,6 +6,7 @@ import _ from 'lodash';
 import { Button } from 'flowbite-react';
 import { Dropzone } from './Dropzone';
 import { AiOutlineClose } from 'react-icons/ai';
+import { User } from '/imports/utils/User';
 
 /** A button that opens a form for a user to upload proof of progression in the SkillTree.
  * Uploads proof photo/videos to an Amazon Web Services S3 storage bucket
@@ -14,6 +15,9 @@ import { AiOutlineClose } from 'react-icons/ai';
  * NOTE: You need an AWS key to upload, see the README and reach out to Mitch to get one
  * */
 export const ProofUploadButton = ({ skill, requirements }) => {
+  // loggedIn username
+  const { username } = User(['username']);
+
   /** CREDITS */
   // AWS s3 upload logic is from https://www.youtube.com/watch?v=SQWJ_goOxGs
 
@@ -155,7 +159,7 @@ export const ProofUploadButton = ({ skill, requirements }) => {
     const proof = {
       title: skill, // TODO proof schema needs to be updated to reflect the fact that we dont have posts/descs, only subskills and requirements
       description: requirements, // TODO schema updates will affect proof display stuff as well
-      user: 'my user', // TODO dummy data. need to be integrated
+      user: username, // TODO dummy data. need to be integrated
       date: new Date(),
       evidenceLink: uploadResults.Location,
       verification: 0,


### PR DESCRIPTION
- Replace dummy 'my user' text for the `user` field in newly created Proofs with the actual logged-in user's username
- Note: unless you have an AWS key you won't be able to create posts to test this, so you can either get one from me or just take my word for it, the code itself is pretty easy to understand