### PR TITLE
St 315 fix pending proof community name hardcoding

### DIFF
--- a/imports/api/publications/SkillTree.js
+++ b/imports/api/publications/SkillTree.js
@@ -298,6 +298,59 @@ Meteor.startup(async () => {
       ],
       admins: ['tennispro'],
       subscribers: ['playerZ', 'coachY']
+    },
+    {
+      _id: 'Climbing',
+      title: 'Climbing',
+      image: 'https://example.com/image1.png',
+      description: 'Learn how to climb effectively.',
+      termsAndConditions: 'For use by climbing enthusiasts and trainers.',
+      tags: ['climbing', 'outdoor', 'sports'],
+      skillNodes: [
+        {
+          id: 'bouldering',
+          type: 'view-node-unlocked',
+          data: {
+            label: 'Bouldering',
+            description: 'Learn how to boulder effectively.',
+            progressXp: 20,
+            requirements: 'Upload a video of yourself bouldering for 5 minutes',
+            xpPoints: 20
+          },
+          position: { x: 300, y: 100 }
+        },
+        {
+          id: 'climbing-techniques',
+          type: 'view-node-locked',
+          data: {
+            label: 'Climbing Techniques',
+            description: 'Learn how to climb with a partner.',
+            progressXp: 30,
+            requirements:
+              'Upload a video of yourself making a climb with at least 10 holds',
+            xpPoints: 30
+          },
+          position: { x: 300, y: 200 }
+        },
+        {
+          id: 'turn',
+          type: 'view-node-locked',
+          data: {
+            label: 'Turning Techniques',
+            description: 'Learn how to turn effectively while climbing.',
+            progressXp: 75,
+            requirements: 'Upload a video of yourself turning while climbing',
+            xpPoints: 75
+          },
+          position: { x: 300, y: 300 }
+        }
+      ],
+      skillEdges: [
+        { id: 'e1', source: 'bouldering', target: 'climbing-techniques' },
+        { id: 'e2', source: 'climbing-techniques', target: 'turn' }
+      ],
+      admins: ['tennispro'],
+      subscribers: ['playerZ', 'coachY']
     }
   ];
 

--- a/imports/api/schemas/Proof.js
+++ b/imports/api/schemas/Proof.js
@@ -37,7 +37,7 @@ Schemas.Proof = new SimpleSchema({
   },
   skillTreeId: {
     type: String,
-    label: 'Skilltree'
+    label: 'Skilltree' // PROBABLY THE EDIT THING IS NOT INCLUDING THIS AND SO IT'S CRASHING BC 'Skilltree is required in proof insertAsync',
   },
   subskill: {
     type: String,

--- a/imports/routes/pages/PendingProofs.jsx
+++ b/imports/routes/pages/PendingProofs.jsx
@@ -9,7 +9,7 @@ import { SampleViewRoutes } from '/imports/routes/components/SampleView';
 
 export const PendingProofsRoutes = [
   {
-    path: 'pendingproofs',
+    path: 'pendingproofs/:skilltreeId',
     element: <PendingProofs />,
     children: [...SampleViewRoutes, ...HelloContainerRoutes]
   }

--- a/imports/ui/components/NavBar.jsx
+++ b/imports/ui/components/NavBar.jsx
@@ -1,13 +1,13 @@
-import React, { useState, useEffect, useRef } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
-import { Meteor } from 'meteor/meteor';
 import {
   Navbar,
   NavbarBrand,
-  NavbarToggle,
   NavbarCollapse,
-  NavbarLink
+  NavbarLink,
+  NavbarToggle
 } from 'flowbite-react';
+import { Meteor } from 'meteor/meteor';
+import React, { useEffect, useRef, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
 
 // JSX UI
 import { UserDropdownMenu } from '/imports/ui/components/UserDropdownMenu';
@@ -142,11 +142,6 @@ export const NavBar = () => {
 
         <NavbarToggle />
         <NavbarCollapse>
-          <NavbarLink as={Link} to="/pendingproofs">
-            <div className="text-white hover:bg-gray-600 px-3 py-2 rounded">
-              Pending Proofs
-            </div>
-          </NavbarLink>
           <NavbarLink as={Link} to="/create">
             <div className="text-white hover:bg-gray-600 px-3 py-2 rounded">
               Create SkillTree

--- a/imports/ui/components/NavigationDropdown.jsx
+++ b/imports/ui/components/NavigationDropdown.jsx
@@ -43,7 +43,7 @@ export const NavigationDropdown = ({ id }) => {
     },
     {
       id: 'pending-proof',
-      label: 'Pending Proof',
+      label: 'Pending Proofs',
       icon: (
         <img
           src="/images/PendingProof.png"
@@ -51,7 +51,7 @@ export const NavigationDropdown = ({ id }) => {
           className="w-8 h-8 rounded-lg object-contain"
         />
       ),
-      link: '/pendingproofs' // Eventually should go to specific skill tree pending proofs
+      link: `/pendingproofs/${id}`
     },
     {
       id: 'upload-evidence',

--- a/imports/ui/components/ProofUploadButton.jsx
+++ b/imports/ui/components/ProofUploadButton.jsx
@@ -14,10 +14,6 @@ import { AiOutlineClose } from 'react-icons/ai';
  * NOTE: You need an AWS key to upload, see the README and reach out to Mitch to get one
  * */
 export const ProofUploadButton = ({ skilltreeId, skill, requirements }) => {
-  useEffect(() => {
-    console.log('skilltreeId', skilltreeId);
-  }, [skilltreeId]);
-
   /** CREDITS */
   // AWS s3 upload logic is from https://www.youtube.com/watch?v=SQWJ_goOxGs
 

--- a/imports/ui/components/ProofUploadButton.jsx
+++ b/imports/ui/components/ProofUploadButton.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Buffer } from 'buffer'; //
 import { Meteor } from 'meteor/meteor';
 import { Random } from 'meteor/random';
@@ -13,7 +13,11 @@ import { AiOutlineClose } from 'react-icons/ai';
  *
  * NOTE: You need an AWS key to upload, see the README and reach out to Mitch to get one
  * */
-export const ProofUploadButton = ({ skill, requirements }) => {
+export const ProofUploadButton = ({ skilltreeId, skill, requirements }) => {
+  useEffect(() => {
+    console.log('skilltreeId', skilltreeId);
+  }, [skilltreeId]);
+
   /** CREDITS */
   // AWS s3 upload logic is from https://www.youtube.com/watch?v=SQWJ_goOxGs
 
@@ -159,7 +163,7 @@ export const ProofUploadButton = ({ skill, requirements }) => {
       date: new Date(),
       evidenceLink: uploadResults.Location,
       verification: 0,
-      skillTreeId: 'my skilltree', // should eventually be a community/skillTree ID
+      skillTreeId: skilltreeId, // should eventually be a community/skillTree ID
       subskill: skill
     };
     await insertProof(proof);

--- a/imports/ui/components/ProofsList.jsx
+++ b/imports/ui/components/ProofsList.jsx
@@ -35,7 +35,7 @@ export const ProofsList = () => {
   useSubscribeSuspense('proof');
   const proofs =
     useFind(ProofCollection, [
-      {},
+      { skillTreeId: 'Climbing' },
       {
         fields: {
           description: 1,

--- a/imports/ui/components/ProofsList.jsx
+++ b/imports/ui/components/ProofsList.jsx
@@ -2,9 +2,9 @@
 import React, { useState } from 'react';
 
 // Meteor-specific imports
+import { useSubscribeSuspense } from 'meteor/communitypackages:react-router-ssr';
 import { Meteor } from 'meteor/meteor';
 import { useFind } from 'meteor/react-meteor-data/suspense';
-import { useSubscribeSuspense } from 'meteor/communitypackages:react-router-ssr';
 
 // Collections & Components
 import { ProofCollection } from '/imports/api/collections/Proof';
@@ -23,7 +23,7 @@ import { ProofDetails } from '/imports/ui/pages/ProofDetails';
  * - Conditional rendering for loading and empty states.
  * - Detail popup shown on 'View Details' click.
  */
-export const ProofsList = () => {
+export const ProofsList = ({ skilltreeId }) => {
   // Track selected proof to open its detail modal
   const [selectedProofId, setSelectedProofId] = useState(null);
 
@@ -35,7 +35,7 @@ export const ProofsList = () => {
   useSubscribeSuspense('proof');
   const proofs =
     useFind(ProofCollection, [
-      { skillTreeId: 'Climbing' },
+      { skillTreeId: { $eq: skilltreeId } },
       {
         fields: {
           description: 1,

--- a/imports/ui/components/SkillTree.jsx
+++ b/imports/ui/components/SkillTree.jsx
@@ -35,6 +35,7 @@ const nodeTypes = {
 };
 
 export const SkillTreeLogic = ({
+  id,
   isAdmin,
   onSave,
   savedNodes,
@@ -220,6 +221,7 @@ export const SkillTreeLogic = ({
           />
         ) : (
           <SkillViewForm
+            skilltreeId={id}
             editingNode={editingNode}
             onCancel={() => setEditingNode(null)}
           />

--- a/imports/ui/components/SkillTreeView.jsx
+++ b/imports/ui/components/SkillTreeView.jsx
@@ -1,8 +1,8 @@
-import React from 'react';
 import { ReactFlowProvider } from '@xyflow/react';
-import { SkillTreeLogic } from './SkillTree';
-import { useFind } from 'meteor/react-meteor-data/suspense';
 import { useSubscribeSuspense } from 'meteor/communitypackages:react-router-ssr';
+import { useFind } from 'meteor/react-meteor-data/suspense';
+import React from 'react';
+import { SkillTreeLogic } from './SkillTree';
 import { SkillTreeCollection } from '/imports/api/collections/SkillTree';
 
 export const SkillTreeView = ({ id, isAdmin, onBack }) => {
@@ -21,6 +21,7 @@ export const SkillTreeView = ({ id, isAdmin, onBack }) => {
   return (
     <ReactFlowProvider>
       <SkillTreeLogic
+        id={id}
         isAdmin={isAdmin}
         onSave={() => {}}
         savedNodes={skilltree.skillNodes}

--- a/imports/ui/components/SkillViewForm.jsx
+++ b/imports/ui/components/SkillViewForm.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ProofUploadButton } from './ProofUploadButton';
 
-export const SkillViewForm = ({ editingNode, onCancel }) => {
+export const SkillViewForm = ({ skilltreeId, editingNode, onCancel }) => {
   const progress = Math.floor(
     (editingNode.progressXp / editingNode.xpPoints) * 100
   );
@@ -23,7 +23,7 @@ export const SkillViewForm = ({ editingNode, onCancel }) => {
           <textarea
             name="description"
             id="description"
-            rows="4"
+            rows={4}
             placeholder="Write your thoughts here..."
             defaultValue={editingNode.description}
             className="block p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300"
@@ -59,7 +59,7 @@ export const SkillViewForm = ({ editingNode, onCancel }) => {
                 {remainder}XP to go!
               </div>
             </div>
-            <div stle={{ marginRight: 10 }}>
+            <div style={{ marginRight: 10 }}>
               {' '}
               {editingNode.progressXp}/{editingNode.xpPoints}{' '}
             </div>
@@ -70,6 +70,7 @@ export const SkillViewForm = ({ editingNode, onCancel }) => {
               Cancel
             </button>
             <ProofUploadButton
+              skilltreeId={skilltreeId}
               skill={editingNode.label}
               requirements={editingNode.requirements}
             />

--- a/imports/ui/pages/PendingProofs.jsx
+++ b/imports/ui/pages/PendingProofs.jsx
@@ -4,24 +4,50 @@ import { Helmet } from 'react-helmet';
 // JSX UI
 import { ProofsList } from '/imports/ui/components/ProofsList';
 import { Fallback } from '/imports/ui/components/Fallback';
+import { useParams } from 'react-router-dom';
+import { useSubscribeSuspense } from 'meteor/communitypackages:react-router-ssr';
+import { useFind } from 'meteor/react-meteor-data/suspense';
+import { SkillTreeCollection } from '/imports/api/collections/SkillTree';
 
-export const PendingProofs = () => (
-  <>
-    <Helmet>
-      <title>SkillTree - Pending Proofs</title>
-    </Helmet>
-    <div className="px-4 pt-4">
-      <button className="min-w-60 text-white-600 rounded-xl bg-[#328E6E]">
-        <h1 className="p-4">
-          <b>
-            <p className="text-white ...">Rock Climbing </p>
-          </b>
-        </h1>
-      </button>
-      {/* Responsive container for ProofsList */}
-      <Suspense fallback={<Fallback msg={'Loading proofs...'} />}>
-        <ProofsList />
-      </Suspense>
-    </div>
-  </>
-);
+export const PendingProofs = () => {
+  const { skilltreeId } = useParams();
+
+  useSubscribeSuspense('skilltrees');
+  const skilltree = useFind(
+    SkillTreeCollection,
+    [
+      { _id: { $eq: skilltreeId } },
+      {
+        fields: {
+          title: 1,
+          description: 1,
+          termsAndConditions: 1
+        }
+      }
+    ],
+    [skilltreeId]
+  )[0];
+
+  if (!skilltree) return <div>Skill Tree not found</div>;
+
+  return (
+    <>
+      <Helmet>
+        <title>SkillTree - Pending Proofs</title>
+      </Helmet>
+      <div className="px-4 pt-4">
+        <button className="min-w-60 text-white-600 rounded-xl bg-[#328E6E]">
+          <h1 className="p-4">
+            <b>
+              <p className="text-white ...">{skilltree.title} </p>
+            </b>
+          </h1>
+        </button>
+        {/* Responsive container for ProofsList */}
+        <Suspense fallback={<Fallback msg={'Loading proofs...'} />}>
+          <ProofsList />
+        </Suspense>
+      </div>
+    </>
+  );
+};

--- a/imports/ui/pages/PendingProofs.jsx
+++ b/imports/ui/pages/PendingProofs.jsx
@@ -2,12 +2,12 @@ import React, { Suspense } from 'react';
 import { Helmet } from 'react-helmet';
 
 // JSX UI
-import { ProofsList } from '/imports/ui/components/ProofsList';
-import { Fallback } from '/imports/ui/components/Fallback';
-import { useParams } from 'react-router-dom';
 import { useSubscribeSuspense } from 'meteor/communitypackages:react-router-ssr';
 import { useFind } from 'meteor/react-meteor-data/suspense';
+import { useParams } from 'react-router-dom';
 import { SkillTreeCollection } from '/imports/api/collections/SkillTree';
+import { Fallback } from '/imports/ui/components/Fallback';
+import { ProofsList } from '/imports/ui/components/ProofsList';
 
 export const PendingProofs = () => {
   const { skilltreeId } = useParams();
@@ -45,7 +45,7 @@ export const PendingProofs = () => {
         </button>
         {/* Responsive container for ProofsList */}
         <Suspense fallback={<Fallback msg={'Loading proofs...'} />}>
-          <ProofsList />
+          <ProofsList skilltreeId={skilltreeId} />
         </Suspense>
       </div>
     </>


### PR DESCRIPTION
- Rework Pending Proofs page to only show proofs from a specific skilltree, given through an id in the url /pendingproofs/[skilltreeId]
- Modify proof upload process to save the current skilltree ID as a field in the proof entry so that proofs are associated with skilltrees to facilitate the above change.
- Move existing Climbing-related dummy proofs to a new dummy skilltree with name and id 'Climbing'
- Remove Pending Proofs navbar item as it no longer makes sense to go to a generic 'pending proofs' page. It is now accessed from the dropdown on each individual Skilltree page.