### PR TITLE
ST-351-dashboard-data (fixes)

### DIFF
--- a/imports/ui/components/Dashboard/SkillTreeCard.jsx
+++ b/imports/ui/components/Dashboard/SkillTreeCard.jsx
@@ -1,12 +1,31 @@
 import React from 'react';
 import { ChevronRight, Users, Crown } from 'lucide-react';
 import { Link } from 'react-router-dom';
+import { useSubscribeSuspense } from 'meteor/communitypackages:react-router-ssr';
+import { useFind } from 'meteor/react-meteor-data/suspense';
+
+// Mongo Collections
+import { SkillTreeCollection } from '/imports/api/collections/SkillTree';
 
 export const SkillTreeCard = ({
-  skillTree,
+  skillTreeId, // SkillTreeId
   showSubscribers = false,
   currentUserId
 }) => {
+  useSubscribeSuspense('skilltrees');
+  const skillTree = useFind(SkillTreeCollection, [
+    { _id: { $eq: skillTreeId } }, // SkillTreeId
+    {
+      fields: {
+        _id: 1,
+        owner: 1,
+        image: 1,
+        title: 1,
+        description: 1,
+        subscribers: 1
+      }
+    }
+  ])[0];
   const isOwner = skillTree.owner === currentUserId;
 
   return (

--- a/imports/ui/components/SkillTreeCommunityView.jsx
+++ b/imports/ui/components/SkillTreeCommunityView.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { Meteor } from 'meteor/meteor';
 import { SkillTreeView } from '../components/SkillTreeView';
 import { SkillTreeCollection } from '/imports/api/collections/SkillTree';
@@ -8,12 +8,14 @@ import { useFind } from 'meteor/react-meteor-data/suspense';
 import { useSubscribeSuspense } from 'meteor/communitypackages:react-router-ssr';
 import { SubscribeButton } from './SubscribeButton';
 import { UserList } from './UserList';
-import { useTracker } from 'meteor/react-meteor-data';
+
+// AuthContext
+import { AuthContext } from '/imports/utils/contexts/AuthContext';2841820
 
 export const SkillTreeCommunityView = () => {
   // extract id from url params
   const { id } = useParams();
-  const userId = useTracker(() => Meteor.userId(), []);
+  const userId = useContext(AuthContext); // Reactive when value changes
 
   useSubscribeSuspense('skilltrees');
   const skilltree = useFind(

--- a/imports/ui/components/SkillTreeCommunityView.jsx
+++ b/imports/ui/components/SkillTreeCommunityView.jsx
@@ -1,5 +1,4 @@
 import React, { useContext } from 'react';
-import { Meteor } from 'meteor/meteor';
 import { SkillTreeView } from '../components/SkillTreeView';
 import { SkillTreeCollection } from '/imports/api/collections/SkillTree';
 import { useParams } from 'react-router-dom';
@@ -10,7 +9,7 @@ import { SubscribeButton } from './SubscribeButton';
 import { UserList } from './UserList';
 
 // AuthContext
-import { AuthContext } from '/imports/utils/contexts/AuthContext';2841820
+import { AuthContext } from '/imports/utils/contexts/AuthContext';
 
 export const SkillTreeCommunityView = () => {
   // extract id from url params

--- a/imports/ui/layouts/DashboardSkillTrees.jsx
+++ b/imports/ui/layouts/DashboardSkillTrees.jsx
@@ -1,0 +1,74 @@
+import React, { Suspense } from 'react';
+import { useSubscribeSuspense } from 'meteor/communitypackages:react-router-ssr';
+import { useFind } from 'meteor/react-meteor-data/suspense';
+import { User } from '/imports/utils/User';
+
+// Mongo Collections
+import { SkillTreeCollection } from '/imports/api/collections/SkillTree';
+
+// JSX UI
+import { SkillTreeCard } from '../components/Dashboard/SkillTreeCard';
+import { EmptyState } from '../components/Dashboard/EmptyState';
+
+export const DashboardSkillTrees = ({ setCommunitiesCount = null }) => {
+  const user = User([
+    '_id',
+    'profile.createdCommunities',
+    'profile.subscribedCommunities'
+  ]);
+  const createdIds = user?.profile?.createdCommunities ?? [];
+  const subscribedIds = user?.profile?.subscribedCommunities ?? [];
+  //Using Set will make all elements unique
+  const allUniqueIds = [...new Set([...createdIds, ...subscribedIds])];
+  // Get all unique skill tree IDs (created + subscribed)
+  useSubscribeSuspense('skilltrees');
+  const allSkillTrees = useFind(SkillTreeCollection, [
+    { _id: { $in: allUniqueIds } },
+    {
+      fields: { _id: 1, owner: 1 }
+    }
+  ]).filter(Boolean); //Some elements were null, so we filter out any null results
+
+  // Filter and categorise skill trees
+  const skillTreesWithRoles = allSkillTrees.map(skillTree => ({
+    ...skillTree,
+    isOwner: skillTree.owner === user?._id,
+    isMember:
+      user?.profile?.subscribedCommunities?.includes(skillTree._id) || false
+  }));
+
+  const displayedSkillTrees = skillTreesWithRoles.slice(0, 6);
+
+  // Sort by ownership first, then by join date or creation date
+  const sortedSkillTrees = [...skillTreesWithRoles].sort((a, b) => {
+    if (a.isOwner && !b.isOwner) return -1;
+    if (!a.isOwner && b.isOwner) return 1;
+    return new Date(b.createdAt) - new Date(a.createdAt);
+  });
+
+  // Update Manage Communities (value)
+  if (setCommunitiesCount) setCommunitiesCount(skillTreesWithRoles.length);
+
+  return (
+    <>
+      <div className="bg-white rounded-xl border border-gray-100 p-4 lg:p-6">
+        {sortedSkillTrees.length > 0 ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {displayedSkillTrees.map(skillTree => (
+              <Suspense>
+                <SkillTreeCard
+                  key={skillTree._id}
+                  skillTreeId={skillTree._id}
+                  showSubscribers={true}
+                  currentUserId={user._id}
+                />
+              </Suspense>
+            ))}
+          </div>
+        ) : (
+          <EmptyState />
+        )}
+      </div>
+    </>
+  );
+};

--- a/imports/ui/layouts/DashboardSkillTrees.jsx
+++ b/imports/ui/layouts/DashboardSkillTrees.jsx
@@ -1,4 +1,4 @@
-import React, { Suspense } from 'react';
+import React from 'react';
 import { useSubscribeSuspense } from 'meteor/communitypackages:react-router-ssr';
 import { useFind } from 'meteor/react-meteor-data/suspense';
 import { User } from '/imports/utils/User';
@@ -55,14 +55,12 @@ export const DashboardSkillTrees = ({ setCommunitiesCount = null }) => {
         {sortedSkillTrees.length > 0 ? (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
             {displayedSkillTrees.map(skillTree => (
-              <Suspense>
-                <SkillTreeCard
-                  key={skillTree._id}
-                  skillTreeId={skillTree._id}
-                  showSubscribers={true}
-                  currentUserId={user._id}
-                />
-              </Suspense>
+              <SkillTreeCard
+                key={skillTree._id}
+                skillTreeId={skillTree._id}
+                showSubscribers={true}
+                currentUserId={user._id}
+              />
             ))}
           </div>
         ) : (

--- a/imports/ui/pages/CreateSkillTree.jsx
+++ b/imports/ui/pages/CreateSkillTree.jsx
@@ -1,7 +1,9 @@
-import React, { useEffect, useState } from 'react';
-import { useTracker } from 'meteor/react-meteor-data';
+import React, { useEffect, useState, useContext } from 'react';
 import { Helmet } from 'react-helmet';
 import { Meteor } from 'meteor/meteor';
+
+// AuthContext
+import { AuthContext } from '/imports/utils/contexts/AuthContext';
 
 // JSX UI
 import { CreateTreeForm } from '/imports/ui/components/CreateTreeForm';
@@ -10,7 +12,7 @@ import { ToastContainer, toast, Flip } from 'react-toastify';
 
 export const CreateSkillTree = () => {
   //Current user id logged in
-  const userId = useTracker(() => Meteor.userId(), []);
+  const userId = useContext(AuthContext); // Reactive when value changes
 
   const [showAddDetailsForm, setShowAddDetailsForm] = useState(true);
   const [showAddSkillsForm, setShowAddSkillsForm] = useState(false);

--- a/imports/ui/pages/Dashboard.jsx
+++ b/imports/ui/pages/Dashboard.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Meteor } from 'meteor/meteor';
 import { useTracker } from 'meteor/react-meteor-data';
 import { Users, ChevronRight } from 'lucide-react';
+import { User } from '/imports/utils/User';
 
 import { SkillTreeCard } from '../components/Dashboard/SkillTreeWidget';
 import { EmptyState } from '../components/Dashboard/EmptyState';
@@ -13,12 +14,12 @@ import {
 import { useNavigate } from 'react-router-dom';
 
 export const Dashboard = () => {
-  const user = useTracker(() => {
-    if (Meteor.isClient) {
-      return Meteor.user();
-    }
-    return null;
-  }, []);
+  const user = User([
+    '_id',
+    'profile.subscribedCommunities',
+    'profile.createdCommunities',
+    'profile.givenName'
+  ]);
 
   const navigate = useNavigate();
   const [greeting, setGreeting] = useState(getGreetingMessage());

--- a/imports/utils/RouteGuard.jsx
+++ b/imports/utils/RouteGuard.jsx
@@ -1,8 +1,7 @@
-import { Meteor } from 'meteor/meteor';
 import React, { useContext } from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
 import { useSubscribeSuspense } from 'meteor/communitypackages:react-router-ssr';
-import { useFind } from 'meteor/react-meteor-data/suspense';
+import { User } from '/imports/utils/User';
 
 // AuthContext
 import { AuthContext } from '/imports/utils/contexts/AuthContext';
@@ -42,12 +41,8 @@ export const ProfileCompleteRoute = ({
   redirectUrl = '/login/extraStep1', // Redirect url can be specified otherwise goes to /login/extraStep1
   requireComplete = true // Whether route requires isProfileComplete to be true or false
 }) => {
-  const userId = useContext(AuthContext); // Reactive when value changes
   useSubscribeSuspense('users'); // Needed to workaround SSR
-  const user = useFind(Meteor.users, [
-    { _id: { $eq: userId } },
-    { fields: { 'profile.isProfileComplete': 1 } }
-  ])[0]; // Suspense waits until data is ready to avoid undefined data
+  const user = User(['profile.isProfileComplete']); // Suspense waits until data is ready to avoid undefined data
   const isProfileComplete = user?.profile?.isProfileComplete;
 
   // Either render children or redirect based on isProfileComplete and requireComplete

--- a/imports/utils/User.js
+++ b/imports/utils/User.js
@@ -1,12 +1,25 @@
 import { Meteor } from 'meteor/meteor';
+import { useContext } from 'react';
+import { useSubscribeSuspense } from 'meteor/communitypackages:react-router-ssr';
+import { useFind } from 'meteor/react-meteor-data/suspense';
+
+// AuthContext
+import { AuthContext } from '/imports/utils/contexts/AuthContext';
 
 // Helper function that takes in a list of fields to return for the logged in user
-export const User = (fields = []) => {
+export const User = (fields = [], options = {}) => {
   const projection = {
     fields: Object.fromEntries(fields.map(field => [field, 1]))
   };
+  const userId = useContext(AuthContext); // Reactive when value changes
+  useSubscribeSuspense('users'); // Needed to workaround SSR
 
-  return Meteor.isClient
-    ? Meteor.user(projection) // user for client
-    : Meteor.userAsync(projection); // userAsync for server
+  return (
+    useFind(Meteor.users, [{ _id: { $eq: userId } }, projection, options])[0] ??
+    undefined
+  );
+
+  // return Meteor.isClient
+  //   ? Meteor.user(projection) // user for client
+  //   : Meteor.userAsync(projection); // userAsync for server
 };


### PR DESCRIPTION
Fixes for ST-351-dashboard-data
- changed useTracker -> useContext(AuthContext) & User([...]) for user data
- resolved slow dashboard loading by switching to useSubscribeSuspense + useFind for Dashboard as well as modularising it.
- switched utils/User implementation to useSubscribeSuspense + useFind instead of Meteor.user/Meteor.userAsync

#4 SSR caches the page once on server startup which causes SSR mismatch issues when the subscribedCommunities value changes
 
There is still a slowdown on page refresh (Dropdown User Menu, search etc) that was introduced from ST-351-dashboard-data not yet fixed.