### PR TITLE
St 327 add skilltree node state to users db table

### DIFF
--- a/imports/api/Methods.js
+++ b/imports/api/Methods.js
@@ -10,6 +10,7 @@ import '/imports/api/methods/Accounts/ValidateStep2';
 import '/imports/api/methods/Accounts/ValidateStep3';
 import '/imports/api/methods/Accounts/ValidateStep4';
 import '/imports/api/methods/SkillTree';
+import '/imports/api/methods/SkillTreeProgress';
 import '/imports/api/methods/SkillForest';
 import '/imports/api/methods/Proof';
 import '/imports/api/methods/Upload';

--- a/imports/api/Methods.js
+++ b/imports/api/Methods.js
@@ -12,6 +12,7 @@ import '/imports/api/methods/Accounts/ForgotPassword';
 import '/imports/api/methods/Accounts/ExtendLoginExpiration';
 import '/imports/api/methods/Accounts/DeleteUserAccount';
 import '/imports/api/methods/SkillTree';
+import '/imports/api/methods/SkillTreeProgress';
 import '/imports/api/methods/SkillForest';
 import '/imports/api/methods/Proof';
 import '/imports/api/methods/Upload';

--- a/imports/api/Publications.js
+++ b/imports/api/Publications.js
@@ -1,6 +1,7 @@
 // Publications
 import '/imports/api/publications/Sample'; // Load Sample Publication (demonstration)
 import '/imports/api/publications/SkillTree';
+import '/imports/api/publications/SkillTreeProgress';
 import '/imports/api/publications/SkillForest';
 import '/imports/api/publications/Proof';
 import '/imports/api/publications/Comments';

--- a/imports/api/collections/SkillTreeProgress.js
+++ b/imports/api/collections/SkillTreeProgress.js
@@ -1,0 +1,3 @@
+import { Mongo } from 'meteor/mongo';
+
+export const SkillTreeProgressCollection = new Mongo.Collection('skillTreeProgress');

--- a/imports/api/collections/SkillTreeProgress.js
+++ b/imports/api/collections/SkillTreeProgress.js
@@ -1,3 +1,5 @@
 import { Mongo } from 'meteor/mongo';
 
-export const SkillTreeProgressCollection = new Mongo.Collection('skillTreeProgress');
+export const SkillTreeProgressCollection = new Mongo.Collection(
+  'skillTreeProgress'
+);

--- a/imports/api/methods/SkillTreeProgress.js
+++ b/imports/api/methods/SkillTreeProgress.js
@@ -1,0 +1,32 @@
+import { Meteor } from 'meteor/meteor';
+import { SkillTreeProgressCollection } from '/imports/api/collections/SkillTreeProgress';
+import { check } from 'meteor/check';
+
+Meteor.methods({
+    async saveSkillTreeProgress(skillTreeId, progressTree) {
+        check(skillTreeId, String);
+        check(progressTree, [Object]);
+
+        const existing = await SkillTreeProgressCollection.findOneAsync({
+            userId: this.userId,
+            skillTreeId
+        });
+
+        if (existing) {
+            return await SkillTreeProgressCollection.updateAsync(
+                { userId: this.userId, skillTreeId },
+                {
+                    $set: {
+                        progress: progressTree,
+                    }
+                }
+            );
+        }
+        else {
+            return await SkillTreeProgressCollection.insertAsync({
+                userId: this.userId,
+                skillTreeId,
+                progress: progressArray,
+            });
+        }
+    });

--- a/imports/api/methods/SkillTreeProgress.js
+++ b/imports/api/methods/SkillTreeProgress.js
@@ -3,30 +3,65 @@ import { SkillTreeProgressCollection } from '/imports/api/collections/SkillTreeP
 import { check } from 'meteor/check';
 
 Meteor.methods({
-    async saveSkillTreeProgress(skillTreeId, progressTree) {
-        check(skillTreeId, String);
-        check(progressTree, [Object]);
-
-        const existing = await SkillTreeProgressCollection.findOneAsync({
-            userId: this.userId,
-            skillTreeId
-        });
-
-        if (existing) {
-            return await SkillTreeProgressCollection.updateAsync(
-                { userId: this.userId, skillTreeId },
-                {
-                    $set: {
-                        progress: progressTree,
-                    }
-                }
-            );
-        }
-        else {
-            return await SkillTreeProgressCollection.insertAsync({
-                userId: this.userId,
-                skillTreeId,
-                progress: progressArray,
-            });
-        }
+  async getSkillTreeProgress(skillTreeId) {
+    check(skillTreeId, String);
+    const existing = await SkillTreeProgressCollection.findOneAsync({
+      userId: this.userId,
+      skillTreeId
     });
+
+    if (existing) {
+      return existing;
+    } else {
+      return null;
+    }
+  },
+
+  async saveSkillTreeProgress(
+    skillTreeId,
+    progressTreeNodes,
+    progressTreeEdges
+  ) {
+    check(skillTreeId, String);
+    check(progressTreeNodes, [Object]);
+    check(progressTreeEdges, [Object]);
+
+    const existing = await SkillTreeProgressCollection.findOneAsync({
+      userId: this.userId,
+      skillTreeId
+    });
+
+    if (existing) {
+      return await SkillTreeProgressCollection.updateAsync(
+        { userId: this.userId, communityId: skillTreeId },
+        {
+          $set: {
+            skillNodes: progressTreeNodes,
+            skillEdges: progressTreeEdges
+          }
+        }
+      );
+    } else {
+      return await SkillTreeProgressCollection.insertAsync({
+        userId: this.userId,
+        skillTreeId,
+        skillNodes: progressTreeNodes,
+        skillEdges: progressTreeEdges
+      });
+    }
+  },
+
+  async removeSkillTreeProgress(skillTreeId) {
+    check(skillTreeId, String);
+    const existing = await SkillTreeProgressCollection.findOneAsync({
+      userId: this.userId,
+      skillTreeId
+    });
+
+    if (existing) {
+      return SkillTreeProgressCollection.remove(skillTreeId);
+    } else {
+      return null;
+    }
+  }
+});

--- a/imports/api/publications/SkillTree.js
+++ b/imports/api/publications/SkillTree.js
@@ -206,12 +206,24 @@ Meteor.startup(async () => {
       tags: ['cricket', 'bat', 'sports'],
       skillNodes: [
         {
+          id: '0',
+          type: 'root',
+          data: {
+            label: 'root',
+            description: 'root',
+            progressXp: null,
+            requirements: 'root',
+            xpPoints: null
+          },
+          position: { x: 0, y: 0 }
+        },
+        {
           id: 'bat',
-          type: 'view-node-unlocked',
+          type: 'view-node-locked',
           data: {
             label: 'Batting',
             description: 'Learn how to bat effectively.',
-            progressXp: 15,
+            progressXp: 0,
             requirements: 'Upload a video of yourself batting for 10 balls',
             xpPoints: 15
           },
@@ -223,7 +235,7 @@ Meteor.startup(async () => {
           data: {
             label: 'Bowling',
             description: 'Learn how to bowl effectively.',
-            progressXp: 25,
+            progressXp: 0,
             requirements: 'Upload a video of yourself bowling 10 balls',
             xpPoints: 25
           },
@@ -235,7 +247,7 @@ Meteor.startup(async () => {
           data: {
             label: 'Fielding',
             description: 'Learn how to field effectively.',
-            progressXp: 35,
+            progressXp: 10,
             requirements: 'Upload a video of yourself fielding and catching',
             xpPoints: 35
           },
@@ -243,8 +255,9 @@ Meteor.startup(async () => {
         }
       ],
       skillEdges: [
-        { id: 'e1', source: 'bat', target: 'bowl' },
-        { id: 'e2', source: 'bowl', target: 'field' }
+        { id: 'e1', source: '0', target: 'bat' },
+        { id: 'e2', source: 'bat', target: 'bowl' },
+        { id: 'e3', source: 'bowl', target: 'field' }
       ],
       admins: ['cricketpro'],
       subscribers: ['user1', 'user2']

--- a/imports/api/publications/SkillTreeProgress.js
+++ b/imports/api/publications/SkillTreeProgress.js
@@ -1,0 +1,142 @@
+import { Meteor } from 'meteor/meteor';
+import { SkillTreeProgressCollection } from '/imports/api/collections/SkillTreeProgress';
+
+Meteor.publish('skillTreeProgress', () => SkillTreeProgressCollection.find());
+
+Meteor.startup(async () => {
+  await SkillTreeProgressCollection.removeAsync({});
+
+  const dummyProgressTree = [
+    {
+      userId: 123123,
+      skillNodes: [
+        {
+          id: '0',
+          type: 'root',
+          data: {
+            label: 'root',
+            description: 'root',
+            progressXp: null,
+            requirements: 'root',
+            xpPoints: null
+          },
+          position: { x: 0, y: 0 }
+        },
+        {
+          id: '1',
+          type: 'view-node-unlocked',
+          data: {
+            label: 'basic dribbling 🏀',
+            description: 'Learn how to dribble the basketball effectively.',
+            progressXp: 10,
+            requirements: 'Upload a video of yourself dribbling for 10 seconds',
+            xpPoints: 10
+          },
+          position: { x: 200, y: 300 }
+        },
+        {
+          id: '2',
+          type: 'view-node-unlocked',
+          data: {
+            label: 'Layup 🏃‍♂️',
+            description:
+              ' A close-range shot taken by driving toward the basket and laying the ball off the backboard.',
+            progressXp: 6,
+            requirements: 'Upload a video of yourself',
+            xpPoints: 10
+          },
+          position: { x: 200, y: 200 }
+        },
+        {
+          id: '3',
+          type: 'view-node-unlocked',
+          data: {
+            label: 'Spin Move 😵',
+            description: 'Learn how to do a spin move.',
+            progressXp: 10,
+            requirements: 'Upload a video of yourself',
+            xpPoints: 20
+          },
+          position: { x: 200, y: 100 }
+        },
+        {
+          id: '4',
+          type: 'view-node-unlocked',
+          data: {
+            label: 'Agility 💨',
+            description: 'Learn how to be agile.',
+            progressXp: 34,
+            requirements:
+              'Upload a video of yourself doing the illinois agility test',
+            xpPoints: 50
+          },
+          position: { x: 0, y: 100 }
+        },
+        {
+          id: '5',
+          type: 'view-node-unlocked',
+          data: {
+            label: 'Shooting Form 🎯',
+            description: 'Learn how to do proper shooting form.',
+            progressXp: 20,
+            requirements: 'Upload a video of yourself',
+            xpPoints: 20
+          },
+          position: { x: -200, y: 300 }
+        },
+        {
+          id: '6',
+          type: 'view-node-unlocked',
+          data: {
+            label: 'Free Throws 💸',
+            description: 'Learn how to do free throws.',
+            progressXp: 6,
+            requirements: 'Upload a video of yourself',
+            xpPoints: 20
+          },
+          position: { x: -150, y: 200 }
+        },
+        {
+          id: '7',
+          type: 'view-node-locked',
+          data: {
+            label: 'Three Pointers 💧',
+            description: 'Learn how to do a spin move.',
+            progressXp: 0,
+            requirements: 'Upload a video of yourself',
+            xpPoints: 20
+          },
+          position: { x: -250, y: 100 }
+        },
+        {
+          id: '8',
+          type: 'view-node-unlocked',
+          data: {
+            label: 'Mid Range 🥶',
+            description: 'Learn how to do a spin move.',
+            progressXp: 4,
+            requirements: 'Upload a video of yourself',
+            xpPoints: 20
+          },
+          position: { x: -350, y: 200 }
+        }
+      ],
+      skillEdges: [
+        { id: 'e1', source: '0', target: '7' },
+        { id: 'e2', source: '0', target: '4' },
+        { id: 'e3', source: '0', target: '3' },
+        { id: 'e4', source: '3', target: '2' },
+        { id: 'e5', source: '2', target: '1' },
+        { id: 'e6', source: '7', target: '6' },
+        { id: 'e7', source: '7', target: '8' },
+        { id: 'e8', source: '6', target: '5' },
+        { id: 'e9', source: '8', target: '5' }
+      ]
+    }
+  ];
+
+  // Insert dummy data
+  for (const progressTree of dummyProgressTree) {
+    await SkillTreeProgressCollection.insertAsync(progressTree);
+  }
+});

--- a/imports/api/schemas/SkillTreeProgress.js
+++ b/imports/api/schemas/SkillTreeProgress.js
@@ -1,0 +1,123 @@
+import SimpleSchema from 'meteor/aldeed:simple-schema';
+import { Schemas } from '/imports/api/Schemas';
+import { SkillTreeProgressCollection } from '../collections/SkillTreeProgress';
+
+const skillDataSchema = new SimpleSchema({
+  label: {
+    type: String,
+    label: 'Skill label',
+    max: 200,
+    min: 1
+  },
+  description: {
+    type: String,
+    label: 'Skill description',
+    max: 1000,
+    min: 1,
+    optional: true
+  },
+  progressXp: {
+    type: Number,
+    label: 'Progress XP',
+    optional: true,
+    defaultValue: 0
+  },
+  xpPoints: {
+    type: Number,
+    label: 'XP Points',
+    optional: true,
+    defaultValue: 0
+  },
+  requirements: {
+    type: String,
+    label: 'Requirements to unlock this skill',
+    max: 1000,
+    min: 1,
+    optional: true
+  },
+  onOpenEditor: {
+    type: Function,
+    label: 'Function to open the editor for this skill',
+    optional: true
+  }
+});
+
+const skillNodeSchema = new SimpleSchema({
+  id: {
+    type: String,
+    label: 'Skill ID',
+    max: 60,
+    min: 1
+  },
+  type: {
+    type: String,
+    label: 'Skill type',
+    optional: true,
+    allowedValues: [
+      'root',
+      'input',
+      'output',
+      'default',
+      'new-empty',
+      'new-populated',
+      'view-node-unlocked',
+      'view-node-locked'
+    ] // add our custom node types here
+  },
+  data: {
+    type: skillDataSchema, // Probs have to change this to have skill name and description
+    label: 'Skill data'
+  },
+  position: {
+    type: Object,
+    label: 'Node position'
+  },
+  'position.x': Number,
+  'position.y': Number
+});
+
+const skillEdgeSchema = new SimpleSchema({
+  id: {
+    type: String,
+    label: 'Edge ID',
+    max: 60,
+    min: 1
+  },
+  source: {
+    type: String,
+    label: 'Source node ID',
+    max: 60,
+    min: 1
+  },
+  target: {
+    type: String,
+    label: 'Target node ID',
+    max: 60,
+    min: 1
+  },
+  animated: {
+    type: Boolean,
+    label: 'Is animated',
+    optional: true
+  }
+});
+
+// Define the schema for the SkillTreeCollection using SimpleSchema to Schemas (for reusability)
+Schemas.SkillTreeProgress = new SimpleSchema({
+  userId: {
+    type: Number,
+    label: 'Unique User ID'
+  },
+  skillNodes: {
+    type: Array,
+    label: 'List of skill nodes'
+  },
+  'skillNodes.$': skillNodeSchema,
+  skillEdges: {
+    type: Array,
+    label: 'List of skill edges'
+  },
+  'skillEdges.$': skillEdgeSchema
+});
+
+SkillTreeProgressCollection.attachSchema(Schemas.SkillTreeProgress);

--- a/imports/api/schemas/SkillTreeProgress.js
+++ b/imports/api/schemas/SkillTreeProgress.js
@@ -108,6 +108,10 @@ Schemas.SkillTreeProgress = new SimpleSchema({
     type: Number,
     label: 'Unique User ID'
   },
+  communityId: {
+    type: Number,
+    label: 'Unique Community ID'
+  },
   skillNodes: {
     type: Array,
     label: 'List of skill nodes'

--- a/imports/ui/components/SkillTree.jsx
+++ b/imports/ui/components/SkillTree.jsx
@@ -49,7 +49,8 @@ export const SkillTreeLogic = ({
       data: {
         ...node.data,
         onOpenEditor: () => handleOpenEditor(node.id)
-      }
+      },
+      draggable: isAdmin
     }));
 
   var initialNodes = attachOpenEditorHandlers(savedNodes) ?? [];

--- a/imports/ui/components/SkillTreeCommunityView.jsx
+++ b/imports/ui/components/SkillTreeCommunityView.jsx
@@ -10,6 +10,63 @@ import { UserList } from './UserList';
 
 // AuthContext
 import { AuthContext } from '/imports/utils/contexts/AuthContext';
+import { Button } from 'flowbite-react';
+import { Meteor } from 'meteor/meteor';
+
+function testSaveTreeProgress(skillTreeId, progressNodes, progressEdges) {
+  Meteor.callAsync(
+    'saveSkillTreeProgress',
+    skillTreeId,
+    progressNodes,
+    progressEdges
+  );
+  console.log('saved tree progress');
+  return;
+}
+
+let progresNodes = [
+  {
+    id: '0',
+    type: 'root',
+    data: {
+      label: 'root',
+      description: 'root',
+      progressXp: null,
+      requirements: 'root',
+      xpPoints: null
+    },
+    position: { x: 0, y: 0 }
+  },
+  {
+    id: 'bat',
+    type: 'view-node-locked',
+    data: {
+      label: 'Batting',
+      description: 'Learn how to bat effectively.',
+      progressXp: 0,
+      requirements: 'Upload a video of yourself batting for 10 balls',
+      xpPoints: 15
+    },
+    position: { x: 100, y: 75 }
+  },
+  {
+    id: 'bowl',
+    type: 'view-node-locked',
+    data: {
+      label: 'Bowling',
+      description: 'Learn how to bowl effectively.',
+      progressXp: 0,
+      requirements: 'Upload a video of yourself bowling 10 balls',
+      xpPoints: 25
+    },
+    position: { x: 300, y: 175 }
+  }
+];
+
+let progressEdges = [
+  { id: 'e1', source: '0', target: 'bat' },
+  { id: 'e2', source: 'bat', target: 'bowl' }
+];
 
 export const SkillTreeCommunityView = () => {
   // extract id from url params
@@ -55,6 +112,9 @@ export const SkillTreeCommunityView = () => {
         </div>
       </div>
       <SkillTreeView id={id} isAdmin={false} />
+      <Button
+        onClick={() => testSaveTreeProgress(id, progresNodes, progressEdges)}
+      ></Button>
     </div>
   );
 };

--- a/imports/ui/components/SkillTreeView.jsx
+++ b/imports/ui/components/SkillTreeView.jsx
@@ -1,22 +1,48 @@
 import { ReactFlowProvider } from '@xyflow/react';
 import { useSubscribeSuspense } from 'meteor/communitypackages:react-router-ssr';
 import { useFind } from 'meteor/react-meteor-data/suspense';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { SkillTreeLogic } from './SkillTree';
 import { SkillTreeCollection } from '/imports/api/collections/SkillTree';
+import { Meteor } from 'meteor/meteor';
 
 export const SkillTreeView = ({ id, isAdmin, onBack }) => {
   useSubscribeSuspense('skilltrees');
-  const skilltree = useFind(SkillTreeCollection, [
-    { _id: { $eq: id } },
-    {
-      fields: {
-        skillNodes: 1,
-        skillEdges: 1
+
+  // Always call useFind at the top level - but don’t necessarily use it right away
+  const fallbackSkillTree = useFind(
+    SkillTreeCollection,
+    [
+      { _id: { $eq: id } },
+      {
+        fields: {
+          skillNodes: 1,
+          skillEdges: 1
+        }
       }
-    },
+    ],
     [id]
-  ])[0];
+  )[0];
+
+  const [skilltree, setSkilltree] = useState(null);
+
+  //Check if user has a saved progress
+  useEffect(() => {
+    Meteor.call('getSkillTreeProgress', id, (err, res) => {
+      if (res) {
+        console.log('Progress found - subscribed');
+        console.log(res);
+        setSkilltree(res);
+      } else {
+        console.log('No progress found - not subscribed');
+        setSkilltree(fallbackSkillTree);
+      }
+    });
+  }, [id, fallbackSkillTree]);
+
+  if (!skilltree) {
+    return <div>Loading...</div>;
+  }
 
   return (
     <ReactFlowProvider>

--- a/imports/ui/components/SubscribeButton.jsx
+++ b/imports/ui/components/SubscribeButton.jsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { Meteor } from 'meteor/meteor';
+import { useFind } from 'meteor/react-meteor-data/suspense';
 import { Button, Spinner } from 'flowbite-react';
+import { SkillTreeCollection } from '/imports/api/collections/SkillTree';
 
 export const SubscribeButton = ({ skillTreeId }) => {
   const [isSubscribed, setIsSubscribed] = useState(false);
@@ -36,6 +38,9 @@ export const SubscribeButton = ({ skillTreeId }) => {
   // call meteor method skilltrees.subscribeUser
   const subscribeUser = async () => {
     try {
+      Meteor.callAsync('saveSkillTreeProgress', skillTreeId);
+      console.log('saved base tree');
+
       return await Meteor.callAsync(
         'skilltrees.subscribeUser',
         skillTreeId,

--- a/imports/ui/components/nodes/ViewNode.jsx
+++ b/imports/ui/components/nodes/ViewNode.jsx
@@ -4,27 +4,26 @@ import { Handle, Position } from '@xyflow/react';
 export function ViewNode({ data, isUnlocked }) {
   const [isHovering, setIsHovering] = useState(false);
 
-  let bgColour;
+  let displayColour;
+  let bgColour = isUnlocked ? '#328E6E' : '#8C8C8C';
+  let hoverBg = isUnlocked ? '#025940' : '#5a5b5a';
+
+
+
 
   const progress = isUnlocked
     ? Math.floor((data.progressXp / data.xpPoints) * 100)
     : 0;
 
-  bgColour = isUnlocked
-    ? isHovering
-      ? '!bg-[#025940]'
-      : '!bg-[#328E6E]'
-    : '!bg-[#8C8C8C]';
+  displayColour = isHovering ? hoverBg : bgColour;
 
-  const ringClasses = isUnlocked
-    ? 'focus:ring-2 focus:ring-[#328E6E] focus:ring-offset-2 hover:ring-2 hover:ring-[#328E6E] hover:ring-offset-2'
-    : '';
+  const ringClasses = `focus:ring-2 focus:ring[#328E6E]] focus:ring-offset-2 hover:ring-2 hover:ring-[#328E6E] hover:ring-offset-2`;
 
   return (
     <div
-      className={`react-flow__node-default ${bgColour} p-2.5 rounded 
-                  focus:outline-none ${ringClasses}`}
-      onClick={isUnlocked ? data.onOpenEditor : null}
+      className={`react-flow__node-default p-2.5 rounded focus:outline-none ${ringClasses}`}
+      style={{ backgroundColor: displayColour }}
+      onClick={data.onOpenEditor}
       onMouseEnter={() => setIsHovering(true)}
       onMouseLeave={() => setIsHovering(false)}
     >
@@ -53,21 +52,6 @@ export function ViewNode({ data, isUnlocked }) {
               className="bg-[#FBBC05] text-xs font-medium text-center p-1 leading-none rounded-full"
               style={{ width: `${progress}%` }}
             ></div>
-          </div>
-        )}
-        {!isUnlocked && (
-          <div
-            className={`
-      absolute inset-0 flex items-center justify-center 
-      transition-opacity duration-300 ease-in-out
-      ${isHovering ? 'opacity-100' : 'opacity-0 pointer-events-none'}
-    `}
-          >
-            <img
-              src="/images/LockIcon.png"
-              alt="Lock Icon"
-              className="w-6 h-6"
-            />
           </div>
         )}
       </div>

--- a/imports/ui/components/nodes/ViewNode.jsx
+++ b/imports/ui/components/nodes/ViewNode.jsx
@@ -8,9 +8,6 @@ export function ViewNode({ data, isUnlocked }) {
   let bgColour = isUnlocked ? '#328E6E' : '#8C8C8C';
   let hoverBg = isUnlocked ? '#025940' : '#5a5b5a';
 
-
-
-
   const progress = isUnlocked
     ? Math.floor((data.progressXp / data.xpPoints) * 100)
     : 0;


### PR DESCRIPTION
# Summary
- Add meteor schema and methods for saving a user's specific progress into new SkillTreeProgress Collection
- For every subscription, a document will be stored in the collection representing a user's progress within a specific skilltree
- Template tree is now stored for each user upon subscription
- Method for saving updated progress after update (like upvote/verification)
- 


# Fixes 
- Restricted dragging nodes to admin only
- Removed locked nodes being non-viewable

# How Has This Been Tested?
- user testing

## Test save on subscription
- On loading a skill tree, should see in console log: 'No progress found - not subscribed'
- After clicking subscribe button, console log should show: 'saved base tree'
- Return to home page then go back to subscribed skilltree, should see in console log: 'Progress found - subscribed'

## Test save after after initial subscription 
- After steps from 'Test save on subscription', click blue button below skill tree canvas
- Button simulates saving a new copy of the tree (the user's new progress) by saving a dummy tree to override user's previous progress 
- On click should show: 'saved tree progress'
- If we go to home page and go back to subscribed skilltree, should see updated tree (with one less node) 

