### PR TITLE
St 314 top commenters leaderboard

### DIFF
--- a/imports/api/publications/Users.js
+++ b/imports/api/publications/Users.js
@@ -1,5 +1,5 @@
-import { Meteor } from 'meteor/meteor';
 import { Accounts } from 'meteor/accounts-base';
+import { Meteor } from 'meteor/meteor';
 
 // Schema
 import '/imports/api/schemas/Users'; // Enable Users Schema Validation
@@ -28,7 +28,8 @@ Meteor.publish('usernames', function (userIds) {
     { _id: { $in: userIds } },
     {
       fields: {
-        username: 1
+        username: 1,
+        profile: 1
       }
     }
   );
@@ -65,7 +66,8 @@ Meteor.startup(async () => {
       createdCommunities: [],
       friends: [],
       skillForests: [],
-      isProfileComplete: true
+      isProfileComplete: true,
+      xpTEMP: 20
     }
   });
 
@@ -74,6 +76,7 @@ Meteor.startup(async () => {
     username: 'example',
     password: 'example123!',
     email: 'example@gmail.com',
+
     profile: {
       givenName: 'John',
       familyName: 'Doe',
@@ -95,7 +98,8 @@ Meteor.startup(async () => {
       createdCommunities: [],
       friends: [],
       skillForests: [],
-      isProfileComplete: true
+      isProfileComplete: true,
+      xpTEMP: 0
     },
     services: {
       password: 'example123!'
@@ -127,7 +131,8 @@ Meteor.startup(async () => {
       createdCommunities: [],
       friends: [],
       skillForests: [],
-      isProfileComplete: true
+      isProfileComplete: true,
+      xpTEMP: 10
     },
     services: {
       password: 'example123!'
@@ -144,7 +149,10 @@ Meteor.startup(async () => {
     const memberUsername = 'member' + String(i);
 
     const memberId = await Accounts.createUserAsync({
-      username: memberUsername
+      username: memberUsername,
+      profile: {
+        xpTEMP: Math.floor(Math.random() * 100)
+      }
     });
 
     await Meteor.callAsync('skilltrees.subscribeUser', 'basketball', memberId);

--- a/imports/api/publications/Users.js
+++ b/imports/api/publications/Users.js
@@ -67,7 +67,8 @@ Meteor.startup(async () => {
       friends: [],
       skillForests: [],
       isProfileComplete: true,
-      xpTEMP: 20
+      xpTEMP: 20,
+      commentNumTEMP: 15
     }
   });
 
@@ -99,7 +100,8 @@ Meteor.startup(async () => {
       friends: [],
       skillForests: [],
       isProfileComplete: true,
-      xpTEMP: 0
+      xpTEMP: 0,
+      commentNumTEMP: 0
     },
     services: {
       password: 'example123!'
@@ -132,7 +134,8 @@ Meteor.startup(async () => {
       friends: [],
       skillForests: [],
       isProfileComplete: true,
-      xpTEMP: 10
+      xpTEMP: 10,
+      commentNumTEMP: 4
     },
     services: {
       password: 'example123!'
@@ -151,7 +154,8 @@ Meteor.startup(async () => {
     const memberId = await Accounts.createUserAsync({
       username: memberUsername,
       profile: {
-        xpTEMP: Math.floor(Math.random() * 100)
+        xpTEMP: Math.floor(Math.random() * 100),
+        commentNumTEMP: Math.floor(Math.random() * 10)
       }
     });
 

--- a/imports/api/schemas/Users.js
+++ b/imports/api/schemas/Users.js
@@ -159,6 +159,11 @@ Schemas.UsersProfile = new SimpleSchema({
     type: Boolean,
     label: 'IsProfileComplete',
     optional: true
+  },
+  xpTEMP: {
+    type: Number,
+    label: 'TEMP xp field',
+    optional: true
   }
 });
 

--- a/imports/api/schemas/Users.js
+++ b/imports/api/schemas/Users.js
@@ -164,6 +164,11 @@ Schemas.UsersProfile = new SimpleSchema({
     type: Number,
     label: 'TEMP xp field',
     optional: true
+  },
+  commentNumTEMP: {
+    type: Number,
+    label: 'TEMP no. comments field',
+    optional: true
   }
 });
 

--- a/imports/ui/components/CommunityLeaderboardList.jsx
+++ b/imports/ui/components/CommunityLeaderboardList.jsx
@@ -48,7 +48,10 @@ export const CommunityLeaderboardList = ({ skillTreeId, filter }) => {
     Meteor.users,
     [
       { _id: { $in: targetSkillTree?.subscribers ?? [] } },
-      { fields: { username: 1 }, sort: { [filter]: -1 } }
+      {
+        fields: { username: 1, [filter]: 1 },
+        sort: { [filter]: -1 }
+      }
     ],
     [targetSkillTree?.subscribers]
   );
@@ -57,7 +60,11 @@ export const CommunityLeaderboardList = ({ skillTreeId, filter }) => {
     <List unstyled className="divide-y divide-gray-200">
       {users.map((user, index) => {
         return (
-          <ListItem key={user.username} className="pb-3">
+          <ListItem
+            key={user._id}
+            className="pb-3"
+            onClick={() => console.log(user)}
+          >
             <div className="flex items-center space-x-4">
               <Badge
                 color="green"
@@ -66,7 +73,7 @@ export const CommunityLeaderboardList = ({ skillTreeId, filter }) => {
               >
                 {String(index + 1)}
               </Badge>
-              <div>{String(user.username)}</div>
+              <div>{`${user.username}, ${user.profile?.xpTEMP}`}</div>
             </div>
           </ListItem>
         );

--- a/imports/ui/components/CommunityLeaderboardList.jsx
+++ b/imports/ui/components/CommunityLeaderboardList.jsx
@@ -19,6 +19,7 @@ import { SkillTreeCollection } from '/imports/api/collections/SkillTree';
  * <CommunityLeaderboardList skillTreeId = {id}></CommunityLeaderboardList>
  *
  * @param {skillTreeId} _id of SkillTree to exctract users from
+ * @param {filter} filter field from user.profile to sort by (String)
  *
  * @returns List of users inside skilltree
  */

--- a/imports/ui/components/CommunityLeaderboardList.jsx
+++ b/imports/ui/components/CommunityLeaderboardList.jsx
@@ -49,8 +49,8 @@ export const CommunityLeaderboardList = ({ skillTreeId, filter }) => {
     [
       { _id: { $in: targetSkillTree?.subscribers ?? [] } },
       {
-        fields: { username: 1, [filter]: 1 },
-        sort: { [filter]: -1 }
+        fields: { username: 1, [`profile.${filter}`]: 1 },
+        sort: { [`profile.${filter}`]: -1 }
       }
     ],
     [targetSkillTree?.subscribers]
@@ -73,7 +73,7 @@ export const CommunityLeaderboardList = ({ skillTreeId, filter }) => {
               >
                 {String(index + 1)}
               </Badge>
-              <div>{`${user.username}, ${user.profile?.xpTEMP}`}</div>
+              <div>{`${user.username}, ${user.profile ? user.profile[filter] : -1}`}</div>
             </div>
           </ListItem>
         );

--- a/imports/ui/components/CommunityLeaderboardList.jsx
+++ b/imports/ui/components/CommunityLeaderboardList.jsx
@@ -73,7 +73,8 @@ export const CommunityLeaderboardList = ({ skillTreeId, filter }) => {
               >
                 {String(index + 1)}
               </Badge>
-              <div>{`${user.username}, ${user.profile ? user.profile[filter] : -1}`}</div>
+              <span>{`${user.username}`}</span>
+              <span>{`${user.profile ? user.profile[filter] : -1}`}</span>
             </div>
           </ListItem>
         );

--- a/imports/ui/components/CommunityLeaderboardList.jsx
+++ b/imports/ui/components/CommunityLeaderboardList.jsx
@@ -22,7 +22,7 @@ import { SkillTreeCollection } from '/imports/api/collections/SkillTree';
  *
  * @returns List of users inside skilltree
  */
-export const CommunityLeaderboardList = ({ skillTreeId }) => {
+export const CommunityLeaderboardList = ({ skillTreeId, filter }) => {
   // useFind to query user data
   useSubscribeSuspense('skilltrees');
   const targetSkillTree = useFind(
@@ -48,7 +48,7 @@ export const CommunityLeaderboardList = ({ skillTreeId }) => {
     Meteor.users,
     [
       { _id: { $in: targetSkillTree?.subscribers ?? [] } },
-      { fields: { username: 1 } }
+      { fields: { username: 1 }, sort: { [filter]: -1 } }
     ],
     [targetSkillTree?.subscribers]
   );
@@ -57,7 +57,7 @@ export const CommunityLeaderboardList = ({ skillTreeId }) => {
     <List unstyled className="divide-y divide-gray-200">
       {users.map((user, index) => {
         return (
-          <ListItem key={user._id} className="pb-3">
+          <ListItem key={user.username} className="pb-3">
             <div className="flex items-center space-x-4">
               <Badge
                 color="green"

--- a/imports/ui/components/CommunityLeaderboardModal.jsx
+++ b/imports/ui/components/CommunityLeaderboardModal.jsx
@@ -58,10 +58,11 @@ export const CommunityLeaderboardModal = () => {
             </Button>
             <Button
               color="green"
-              onClick={() => setFilter('_id')}
+              onClick={() => setFilter('commentNumTEMP')}
               pill
               style={{
-                backgroundColor: filter === '_id' ? '#328E6E' : '#7eaa9b'
+                backgroundColor:
+                  filter === 'commentNumTEMP' ? '#328E6E' : '#7eaa9b'
               }}
               className="cursor-pointer text-lg font-bold text-white leading-none !font-sans flex items-center gap-3 px-6 py-3 rounded-[22px] transition-all duration-200 hover:bg-[#2a7a5e] focus:outline-none focus:ring-0"
             >

--- a/imports/ui/components/CommunityLeaderboardModal.jsx
+++ b/imports/ui/components/CommunityLeaderboardModal.jsx
@@ -35,7 +35,7 @@ export const CommunityLeaderboardModal = () => {
   };
 
   // Manage swapping between different leaderboard ordering metrics
-  const [filter, setFilter] = useState('username');
+  const [filter, setFilter] = useState('profile.xpTEMP');
 
   return (
     <Modal show={true} onClose={closeModal} dismissible size="7xl">
@@ -46,14 +46,15 @@ export const CommunityLeaderboardModal = () => {
           <div className="flex flex-row items-center justify-between px-4 gap-1">
             <Button
               color="green"
-              onClick={() => setFilter('username')}
+              onClick={() => setFilter('profile.xpTEMP')}
               pill
               style={{
-                backgroundColor: filter === 'username' ? '#328E6E' : '#7eaa9b'
+                backgroundColor:
+                  filter === 'profile.xpTEMP' ? '#328E6E' : '#7eaa9b'
               }}
               className={`cursor-pointer text-lg font-bold text-white leading-none !font-sans flex items-center gap-3 px-6 py-3 rounded-[22px] transition-all duration-200 hover:bg-[#2a7a5e] focus:outline-none focus:ring-0`}
             >
-              Top username
+              Top XP
             </Button>
             <Button
               color="green"

--- a/imports/ui/components/CommunityLeaderboardModal.jsx
+++ b/imports/ui/components/CommunityLeaderboardModal.jsx
@@ -1,4 +1,4 @@
-import React, { use, useState } from 'react';
+import React, { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import {
@@ -84,7 +84,7 @@ export const CommunityLeaderboardModal = () => {
           color="green"
           onClick={closeModal}
           pill
-          className="cursor-pointer position-relative text-lg font-bold mt-2 text-white font-semibold leading-none !font-sans flex items-center gap-3 px-6 py-3 bg-[#328E6E] rounded-[22px] transition-all duration-200 hover:bg-[#2a7a5e] focus:outline-none focus:ring-0"
+          className="cursor-pointer position-relative text-lg font-bold mt-2 text-white leading-none !font-sans flex items-center gap-3 px-6 py-3 bg-[#328E6E] rounded-[22px] transition-all duration-200 hover:bg-[#2a7a5e] focus:outline-none focus:ring-0"
         >
           Close
         </Button>

--- a/imports/ui/components/CommunityLeaderboardModal.jsx
+++ b/imports/ui/components/CommunityLeaderboardModal.jsx
@@ -1,12 +1,12 @@
-import React from 'react';
+import React, { use, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import {
+  Button,
   Modal,
-  ModalHeader,
   ModalBody,
   ModalFooter,
-  Button
+  ModalHeader
 } from 'flowbite-react';
 import { CommunityLeaderboardList } from '/imports/ui/components/CommunityLeaderboardList';
 
@@ -34,9 +34,41 @@ export const CommunityLeaderboardModal = () => {
     navigate(-1);
   };
 
+  // Manage swapping between different leaderboard ordering metrics
+  const [filter, setFilter] = useState('xp');
+
   return (
     <Modal show={true} onClose={closeModal} dismissible size="7xl">
-      <ModalHeader>Community Leaderboard</ModalHeader>
+      <ModalHeader>
+        <div className="flex flex-row items-center justify-between w-full">
+          <span>Community Leaderboard</span>
+          {/* TODO abstract this out into a separate component */}
+          <div className="flex flex-row items-center justify-between px-4 gap-1">
+            <Button
+              color="green"
+              onClick={() => setFilter('xp')}
+              pill
+              style={{
+                backgroundColor: filter === 'xp' ? '#328E6E' : '#7eaa9b'
+              }}
+              className={`cursor-pointer text-lg font-bold text-white leading-none !font-sans flex items-center gap-3 px-6 py-3 rounded-[22px] transition-all duration-200 hover:bg-[#2a7a5e] focus:outline-none focus:ring-0`}
+            >
+              Top XP
+            </Button>
+            <Button
+              color="green"
+              onClick={() => setFilter('comments')}
+              pill
+              style={{
+                backgroundColor: filter === 'comments' ? '#328E6E' : '#7eaa9b'
+              }}
+              className="cursor-pointer text-lg font-bold text-white leading-none !font-sans flex items-center gap-3 px-6 py-3 rounded-[22px] transition-all duration-200 hover:bg-[#2a7a5e] focus:outline-none focus:ring-0"
+            >
+              Top Commenters
+            </Button>
+          </div>
+        </div>
+      </ModalHeader>
       <ModalBody className="w-full h-full min-h-[70vh]">
         <div className="space-y-6">
           <CommunityLeaderboardList skillTreeId={id}></CommunityLeaderboardList>

--- a/imports/ui/components/CommunityLeaderboardModal.jsx
+++ b/imports/ui/components/CommunityLeaderboardModal.jsx
@@ -34,8 +34,9 @@ export const CommunityLeaderboardModal = () => {
     navigate(-1);
   };
 
-  // Manage swapping between different leaderboard ordering metrics
-  const [filter, setFilter] = useState('profile.xpTEMP');
+  // Manage swapping between different leaderboard ordering metrics.
+  // NOTE: All filters must come from the user profile, not the root-level user fields like username, email, password.
+  const [filter, setFilter] = useState('xpTEMP');
 
   return (
     <Modal show={true} onClose={closeModal} dismissible size="7xl">
@@ -46,11 +47,10 @@ export const CommunityLeaderboardModal = () => {
           <div className="flex flex-row items-center justify-between px-4 gap-1">
             <Button
               color="green"
-              onClick={() => setFilter('profile.xpTEMP')}
+              onClick={() => setFilter('xpTEMP')}
               pill
               style={{
-                backgroundColor:
-                  filter === 'profile.xpTEMP' ? '#328E6E' : '#7eaa9b'
+                backgroundColor: filter === 'xpTEMP' ? '#328E6E' : '#7eaa9b'
               }}
               className={`cursor-pointer text-lg font-bold text-white leading-none !font-sans flex items-center gap-3 px-6 py-3 rounded-[22px] transition-all duration-200 hover:bg-[#2a7a5e] focus:outline-none focus:ring-0`}
             >

--- a/imports/ui/components/CommunityLeaderboardModal.jsx
+++ b/imports/ui/components/CommunityLeaderboardModal.jsx
@@ -35,7 +35,7 @@ export const CommunityLeaderboardModal = () => {
   };
 
   // Manage swapping between different leaderboard ordering metrics
-  const [filter, setFilter] = useState('xp');
+  const [filter, setFilter] = useState('username');
 
   return (
     <Modal show={true} onClose={closeModal} dismissible size="7xl">
@@ -46,21 +46,21 @@ export const CommunityLeaderboardModal = () => {
           <div className="flex flex-row items-center justify-between px-4 gap-1">
             <Button
               color="green"
-              onClick={() => setFilter('xp')}
+              onClick={() => setFilter('username')}
               pill
               style={{
-                backgroundColor: filter === 'xp' ? '#328E6E' : '#7eaa9b'
+                backgroundColor: filter === 'username' ? '#328E6E' : '#7eaa9b'
               }}
               className={`cursor-pointer text-lg font-bold text-white leading-none !font-sans flex items-center gap-3 px-6 py-3 rounded-[22px] transition-all duration-200 hover:bg-[#2a7a5e] focus:outline-none focus:ring-0`}
             >
-              Top XP
+              Top username
             </Button>
             <Button
               color="green"
-              onClick={() => setFilter('comments')}
+              onClick={() => setFilter('_id')}
               pill
               style={{
-                backgroundColor: filter === 'comments' ? '#328E6E' : '#7eaa9b'
+                backgroundColor: filter === '_id' ? '#328E6E' : '#7eaa9b'
               }}
               className="cursor-pointer text-lg font-bold text-white leading-none !font-sans flex items-center gap-3 px-6 py-3 rounded-[22px] transition-all duration-200 hover:bg-[#2a7a5e] focus:outline-none focus:ring-0"
             >
@@ -71,7 +71,10 @@ export const CommunityLeaderboardModal = () => {
       </ModalHeader>
       <ModalBody className="w-full h-full min-h-[70vh]">
         <div className="space-y-6">
-          <CommunityLeaderboardList skillTreeId={id}></CommunityLeaderboardList>
+          <CommunityLeaderboardList
+            skillTreeId={id}
+            filter={filter}
+          ></CommunityLeaderboardList>
         </div>
       </ModalBody>
       <ModalFooter>


### PR DESCRIPTION
NOTE: In the event of having to make quick fixes or under limited time, just provide a quick summary. Delete the rest.

# Summary

Please include a summary of the changes (dot points)
- Splits the leaderboard into two, an XP leaderboard and a Top Commenters leaderboard, toggleable with buttons at the top of the modal
- Displays the XP/#Comments number next to the username (pending proper styling and headings in future)
- Currently uses dummy `xpTEMP` and `commentNumTEMP` fields in user.profile. Proper XP database integration will be implemented in ST-362 pending other teams' work on the XP system. Proper No. Comments database integration will be implemented in ST-313.
- Known issue: quickly switching between the two leaderboards can cause the data to stop updating when you switch

# Related Issues:

_Fixes ST-314_



# Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Please describe in detail how you tested your changes (i.e., User Testing, Unit Testing)
Provide instructions so we can reproduce.

- [x] Manual testing


# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, specifically in difficult-to-understand code areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have conducted tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been carefully merged and published in downstream modules

