### PR TITLE
Store proofID in skillNode, and update XP and upvote handling

### DIFF
--- a/imports/api/publications/SkillTree.js
+++ b/imports/api/publications/SkillTree.js
@@ -25,7 +25,8 @@ Meteor.startup(async () => {
           data: {
             label: 'root',
             description: 'root',
-            progressXp: null,
+            netUpvotesRequired: null,
+            currentUpvotes: null,
             requirements: 'root',
             xpPoints: null
           },
@@ -37,8 +38,9 @@ Meteor.startup(async () => {
           data: {
             label: 'basic dribbling 🏀',
             description: 'Learn how to dribble the basketball effectively.',
-            progressXp: 10,
             requirements: 'Upload a video of yourself dribbling for 10 seconds',
+            netUpvotesRequired: 10,
+            currentNetUpvotes: 5,
             xpPoints: 10
           },
           position: { x: 200, y: 300 }
@@ -50,8 +52,9 @@ Meteor.startup(async () => {
             label: 'Layup 🏃‍♂️',
             description:
               ' A close-range shot taken by driving toward the basket and laying the ball off the backboard.',
-            progressXp: 6,
             requirements: 'Upload a video of yourself',
+            netUpvotesRequired: 10,
+            currentNetUpvotes: 0,
             xpPoints: 10
           },
           position: { x: 200, y: 200 }
@@ -62,9 +65,10 @@ Meteor.startup(async () => {
           data: {
             label: 'Spin Move 😵',
             description: 'Learn how to do a spin move.',
-            progressXp: 0,
             requirements: 'Upload a video of yourself',
-            xpPoints: 20
+            netUpvotesRequired: 15,
+            currentNetUpvotes: 3,
+            xpPoints: 15
           },
           position: { x: 200, y: 100 }
         },
@@ -74,9 +78,10 @@ Meteor.startup(async () => {
           data: {
             label: 'Agility 💨',
             description: 'Learn how to be agile.',
-            progressXp: 34,
             requirements:
               'Upload a video of yourself doing the illinois agility test',
+            netUpvotesRequired: 10,
+            currentNetUpvotes: 0,
             xpPoints: 50
           },
           position: { x: 0, y: 100 }
@@ -87,8 +92,9 @@ Meteor.startup(async () => {
           data: {
             label: 'Shooting Form 🎯',
             description: 'Learn how to do proper shooting form.',
-            progressXp: 20,
             requirements: 'Upload a video of yourself',
+            netUpvotesRequired: 10,
+            currentNetUpvotes: 0,
             xpPoints: 20
           },
           position: { x: -200, y: 300 }
@@ -99,8 +105,9 @@ Meteor.startup(async () => {
           data: {
             label: 'Free Throws 💸',
             description: 'Learn how to do free throws.',
-            progressXp: 6,
             requirements: 'Upload a video of yourself',
+            netUpvotesRequired: 10,
+            currentNetUpvotes: 0,
             xpPoints: 20
           },
           position: { x: -150, y: 200 }
@@ -111,8 +118,9 @@ Meteor.startup(async () => {
           data: {
             label: 'Three Pointers 💧',
             description: 'Learn how to do a spin move.',
-            progressXp: 0,
             requirements: 'Upload a video of yourself',
+            netUpvotesRequired: 10,
+            currentNetUpvotes: 0,
             xpPoints: 20
           },
           position: { x: -250, y: 100 }
@@ -123,8 +131,9 @@ Meteor.startup(async () => {
           data: {
             label: 'Mid Range 🥶',
             description: 'Learn how to do a spin move.',
-            progressXp: 4,
             requirements: 'Upload a video of yourself',
+            netUpvotesRequired: 10,
+            currentNetUpvotes: 0,
             xpPoints: 20
           },
           position: { x: -350, y: 200 }
@@ -159,9 +168,10 @@ Meteor.startup(async () => {
           data: {
             label: 'Passing',
             description: 'Learn how to pass the ball effectively.',
-            progressXp: 10,
             requirements:
               'Upload a video of yourself passing back and forth 3 times with another player',
+            netUpvotesRequired: 10,
+            currentNetUpvotes: 0,
             xpPoints: 10
           },
           position: { x: 300, y: 100 }
@@ -172,8 +182,9 @@ Meteor.startup(async () => {
           data: {
             label: 'Shooting',
             description: 'Learn how to shoot and score',
-            progressXp: 30,
             requirements: 'Upload a video of yourself scoring a goal',
+            netUpvotesRequired: 10,
+            currentNetUpvotes: 0,
             xpPoints: 30
           },
           position: { x: 100, y: 250 }
@@ -184,8 +195,9 @@ Meteor.startup(async () => {
           data: {
             label: 'Goalkeeping',
             description: 'Learn how to defend the goal',
-            progressXp: 50,
             requirements: 'Upload a video of yourself making a save',
+            netUpvotesRequired: 10,
+            currentNetUpvotes: 0,
             xpPoints: 50
           },
           position: { x: 500, y: 350 }
@@ -212,8 +224,9 @@ Meteor.startup(async () => {
           data: {
             label: 'root',
             description: 'root',
-            progressXp: null,
             requirements: 'root',
+            netUpvotesRequired: null,
+            currentNetUpvotes: null,
             xpPoints: null
           },
           position: { x: 0, y: 0 }
@@ -224,8 +237,9 @@ Meteor.startup(async () => {
           data: {
             label: 'Batting',
             description: 'Learn how to bat effectively.',
-            progressXp: 0,
             requirements: 'Upload a video of yourself batting for 10 balls',
+            netUpvotesRequired: 10,
+            currentNetUpvotes: 0,
             xpPoints: 15
           },
           position: { x: 100, y: 75 }
@@ -236,8 +250,9 @@ Meteor.startup(async () => {
           data: {
             label: 'Bowling',
             description: 'Learn how to bowl effectively.',
-            progressXp: 0,
             requirements: 'Upload a video of yourself bowling 10 balls',
+            netUpvotesRequired: 10,
+            currentNetUpvotes: 0,
             xpPoints: 25
           },
           position: { x: 300, y: 175 }
@@ -248,8 +263,9 @@ Meteor.startup(async () => {
           data: {
             label: 'Fielding',
             description: 'Learn how to field effectively.',
-            progressXp: 10,
             requirements: 'Upload a video of yourself fielding and catching',
+            netUpvotesRequired: 10,
+            currentNetUpvotes: 0,
             xpPoints: 35
           },
           position: { x: 500, y: 275 }
@@ -277,8 +293,9 @@ Meteor.startup(async () => {
           data: {
             label: 'Serving',
             description: 'Learn how to serve the tennis ball effectively.',
-            progressXp: 20,
             requirements: 'Upload a video of yourself serving 5 times',
+            netUpvotesRequired: 10,
+            currentNetUpvotes: 0,
             xpPoints: 20
           },
           position: { x: 300, y: 100 }
@@ -289,9 +306,10 @@ Meteor.startup(async () => {
           data: {
             label: 'Rally Techniques',
             description: 'Learn how to rally with a partner.',
-            progressXp: 30,
             requirements:
               'Upload a video of yourself making a rally with at least 10 hits',
+            netUpvotesRequired: 10,
+            currentNetUpvotes: 0,
             xpPoints: 30
           },
           position: { x: 300, y: 200 }
@@ -302,9 +320,10 @@ Meteor.startup(async () => {
           data: {
             label: 'Serve and Volley',
             description: 'Learn how serve and volley for the winner',
-            progressXp: 75,
             requirements:
               'Upload a video of yourself winning a point with a serve and volley',
+            netUpvotesRequired: 10,
+            currentNetUpvotes: 0,
             xpPoints: 75
           },
           position: { x: 300, y: 300 }
@@ -332,8 +351,9 @@ Meteor.startup(async () => {
           data: {
             label: 'Bouldering',
             description: 'Learn how to boulder effectively.',
-            progressXp: 20,
             requirements: 'Upload a video of yourself bouldering for 5 minutes',
+            netUpvotesRequired: 10,
+            currentNetUpvotes: 0,
             xpPoints: 20
           },
           position: { x: 300, y: 100 }
@@ -344,9 +364,10 @@ Meteor.startup(async () => {
           data: {
             label: 'Climbing Techniques',
             description: 'Learn how to climb with a partner.',
-            progressXp: 30,
             requirements:
               'Upload a video of yourself making a climb with at least 10 holds',
+            netUpvotesRequired: 10,
+            currentNetUpvotes: 0,
             xpPoints: 30
           },
           position: { x: 300, y: 200 }
@@ -357,8 +378,9 @@ Meteor.startup(async () => {
           data: {
             label: 'Turning Techniques',
             description: 'Learn how to turn effectively while climbing.',
-            progressXp: 75,
             requirements: 'Upload a video of yourself turning while climbing',
+            netUpvotesRequired: 10,
+            currentNetUpvotes: 0,
             xpPoints: 75
           },
           position: { x: 300, y: 300 }
@@ -400,9 +422,10 @@ Meteor.startup(async () => {
           data: {
             label: 'Force Sensitivity ✨',
             description: 'Learn how to sense the Force.',
-            progressXp: 5,
             requirements:
               'Watch a video about the Force and answer 3 quiz questions.',
+            netUpvotesRequired: 10,
+            currentNetUpvotes: 0,
             xpPoints: 10
           },
           position: { x: 150, y: 100 }
@@ -413,8 +436,9 @@ Meteor.startup(async () => {
           data: {
             label: 'Lightsaber Basics ⚔️',
             description: 'Understand the basic lightsaber forms.',
-            progressXp: 10,
             requirements: 'Upload a video of you mimicking Form I (Shii-Cho).',
+            netUpvotesRequired: 10,
+            currentNetUpvotes: 0,
             xpPoints: 15
           },
           position: { x: -150, y: 100 }
@@ -425,8 +449,9 @@ Meteor.startup(async () => {
           data: {
             label: 'Jedi Meditation 🧘‍♂️',
             description: 'Develop mental clarity and connection to the Force.',
-            progressXp: 10,
             requirements: 'Record a 2-minute meditation log.',
+            netUpvotesRequired: 10,
+            currentNetUpvotes: 0,
             xpPoints: 10
           },
           position: { x: 0, y: 200 }
@@ -437,9 +462,10 @@ Meteor.startup(async () => {
           data: {
             label: 'Force Telekinesis 🌀',
             description: 'Master the art of moving objects with your mind.',
-            progressXp: 0,
             requirements:
               'Upload a short creative video simulating telekinesis.',
+            netUpvotesRequired: 10,
+            currentNetUpvotes: 0,
             xpPoints: 20
           },
           position: { x: 200, y: 300 }
@@ -450,10 +476,11 @@ Meteor.startup(async () => {
           data: {
             label: 'Lightsaber Duel 🥷',
             description: 'Engage in your first training duel.',
-            progressXp: 0,
             requirements:
               'Upload a video of a lightsaber duel (with a friend or animation).',
-            xpPoints: 30
+            netUpvotesRequired: 10,
+            currentNetUpvotes: 0,
+            xpPoints: 10
           },
           position: { x: -200, y: 300 }
         }

--- a/imports/api/publications/SkillTreeProgress.js
+++ b/imports/api/publications/SkillTreeProgress.js
@@ -28,9 +28,11 @@ Meteor.startup(async () => {
           data: {
             label: 'basic dribbling 🏀',
             description: 'Learn how to dribble the basketball effectively.',
-            progressXp: 10,
+            netUpvotesRequired: 10,
+            currentNetUpvotes: 0,
+            xpPoints: 10,
             requirements: 'Upload a video of yourself dribbling for 10 seconds',
-            xpPoints: 10
+            proofId: 'testProofId'
           },
           position: { x: 200, y: 300 }
         },
@@ -41,8 +43,9 @@ Meteor.startup(async () => {
             label: 'Layup 🏃‍♂️',
             description:
               ' A close-range shot taken by driving toward the basket and laying the ball off the backboard.',
-            progressXp: 6,
             requirements: 'Upload a video of yourself',
+            netUpvotesRequired: 10,
+            currentNetUpvotes: 0,
             xpPoints: 10
           },
           position: { x: 200, y: 200 }
@@ -53,9 +56,10 @@ Meteor.startup(async () => {
           data: {
             label: 'Spin Move 😵',
             description: 'Learn how to do a spin move.',
-            progressXp: 10,
             requirements: 'Upload a video of yourself',
-            xpPoints: 20
+            netUpvotesRequired: 15,
+            currentNetUpvotes: 3,
+            xpPoints: 15
           },
           position: { x: 200, y: 100 }
         },
@@ -65,10 +69,11 @@ Meteor.startup(async () => {
           data: {
             label: 'Agility 💨',
             description: 'Learn how to be agile.',
-            progressXp: 34,
             requirements:
               'Upload a video of yourself doing the illinois agility test',
-            xpPoints: 50
+            netUpvotesRequired: 10,
+            currentNetUpvotes: 0,
+            xpPoints: 10
           },
           position: { x: 0, y: 100 }
         },
@@ -78,9 +83,10 @@ Meteor.startup(async () => {
           data: {
             label: 'Shooting Form 🎯',
             description: 'Learn how to do proper shooting form.',
-            progressXp: 20,
             requirements: 'Upload a video of yourself',
-            xpPoints: 20
+            netUpvotesRequired: 10,
+            currentNetUpvotes: 0,
+            xpPoints: 10
           },
           position: { x: -200, y: 300 }
         },
@@ -90,9 +96,10 @@ Meteor.startup(async () => {
           data: {
             label: 'Free Throws 💸',
             description: 'Learn how to do free throws.',
-            progressXp: 6,
             requirements: 'Upload a video of yourself',
-            xpPoints: 20
+            netUpvotesRequired: 10,
+            currentNetUpvotes: 0,
+            xpPoints: 10
           },
           position: { x: -150, y: 200 }
         },
@@ -102,9 +109,10 @@ Meteor.startup(async () => {
           data: {
             label: 'Three Pointers 💧',
             description: 'Learn how to do a spin move.',
-            progressXp: 0,
             requirements: 'Upload a video of yourself',
-            xpPoints: 20
+            netUpvotesRequired: 10,
+            currentNetUpvotes: 0,
+            xpPoints: 10
           },
           position: { x: -250, y: 100 }
         },
@@ -114,9 +122,10 @@ Meteor.startup(async () => {
           data: {
             label: 'Mid Range 🥶',
             description: 'Learn how to do a spin move.',
-            progressXp: 4,
             requirements: 'Upload a video of yourself',
-            xpPoints: 20
+            netUpvotesRequired: 10,
+            currentNetUpvotes: 0,
+            xpPoints: 10
           },
           position: { x: -350, y: 200 }
         }

--- a/imports/api/schemas/SkillTree.js
+++ b/imports/api/schemas/SkillTree.js
@@ -16,17 +16,28 @@ const skillDataSchema = new SimpleSchema({
     min: 1,
     optional: true
   },
-  progressXp: {
+  netUpvotesRequired: {
     type: Number,
-    label: 'Progress XP',
+    label: 'Net Upvotes Required to complete this skill',
+    optional: true,
+    defaultValue: 0
+  },
+  currentNetUpvotes: {
+    type: Number,
+    label: 'Current Net Upvotes',
     optional: true,
     defaultValue: 0
   },
   xpPoints: {
     type: Number,
-    label: 'XP Points',
+    label: 'XP Points earned for completing this skill',
     optional: true,
     defaultValue: 0
+  },
+  proofId: {
+    type: String,
+    label: 'ID of the corresponding proof object for this skill',
+    optional: true
   },
   requirements: {
     type: String,
@@ -65,7 +76,7 @@ const skillNodeSchema = new SimpleSchema({
     ] // add our custom node types here
   },
   data: {
-    type: skillDataSchema, // Probs have to change this to have skill name and description
+    type: skillDataSchema,
     label: 'Skill data'
   },
   position: {

--- a/imports/api/schemas/SkillTreeProgress.js
+++ b/imports/api/schemas/SkillTreeProgress.js
@@ -16,17 +16,28 @@ const skillDataSchema = new SimpleSchema({
     min: 1,
     optional: true
   },
-  progressXp: {
+  netUpvotesRequired: {
     type: Number,
-    label: 'Progress XP',
+    label: 'Net Upvotes Required to complete this skill',
+    optional: true,
+    defaultValue: 0
+  },
+  currentNetUpvotes: {
+    type: Number,
+    label: 'Current Net Upvotes',
     optional: true,
     defaultValue: 0
   },
   xpPoints: {
     type: Number,
-    label: 'XP Points',
+    label: 'XP Points earned for completing this skill',
     optional: true,
     defaultValue: 0
+  },
+  proofId: {
+    type: String,
+    label: 'ID of the corresponding proof object for this skill',
+    optional: true
   },
   requirements: {
     type: String,
@@ -65,7 +76,7 @@ const skillNodeSchema = new SimpleSchema({
     ] // add our custom node types here
   },
   data: {
-    type: skillDataSchema, // Probs have to change this to have skill name and description
+    type: skillDataSchema,
     label: 'Skill data'
   },
   position: {
@@ -121,7 +132,12 @@ Schemas.SkillTreeProgress = new SimpleSchema({
     type: Array,
     label: 'List of skill edges'
   },
-  'skillEdges.$': skillEdgeSchema
+  'skillEdges.$': skillEdgeSchema,
+  xpPoints: {
+    type: Number,
+    label: 'Total XP Points earned by the user for this skilltree',
+    defaultValue: 0
+  }
 });
 
 SkillTreeProgressCollection.attachSchema(Schemas.SkillTreeProgress);

--- a/imports/ui/components/ProofUploadButton.jsx
+++ b/imports/ui/components/ProofUploadButton.jsx
@@ -14,7 +14,12 @@ import { User } from '/imports/utils/User';
  *
  * NOTE: You need an AWS key to upload, see the README and reach out to Mitch to get one
  * */
-export const ProofUploadButton = ({ skilltreeId, skill, requirements }) => {
+export const ProofUploadButton = ({
+  skilltreeId,
+  skill,
+  requirements,
+  onUploadProof
+}) => {
   // loggedIn username
   const currentUserId = Meteor.userId();
   const { username } = User(['username']);
@@ -144,7 +149,8 @@ export const ProofUploadButton = ({ skilltreeId, skill, requirements }) => {
    * @returns {Promise<void>}
    */
   const insertProof = async data => {
-    await Meteor.callAsync('insertProof', data);
+    const proofId = await Meteor.callAsync('insertProof', data);
+    onUploadProof(proofId);
   };
 
   /**  Main Functions */

--- a/imports/ui/components/SkillTree.jsx
+++ b/imports/ui/components/SkillTree.jsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useRef, useState, useEffect } from 'react';
+import { Meteor } from 'meteor/meteor';
 import {
   ReactFlow,
   Background,
@@ -157,6 +158,17 @@ export const SkillTreeLogic = ({
     onSave({ nodes, edges });
   };
 
+  // stores proofId in node data, then syncs with DB
+  const handleLinkProofToNode = proofId => {
+    const updatedNodes = nodes.map(node =>
+      node.id === editingNode.id
+        ? { ...node, data: { ...node.data, proofId } }
+        : node
+    );
+    setNodes(updatedNodes);
+    Meteor.callAsync('saveSkillTreeProgress', id, updatedNodes, edges);
+  };
+
   return (
     <>
       {isAdmin ? (
@@ -225,6 +237,7 @@ export const SkillTreeLogic = ({
             skilltreeId={id}
             editingNode={editingNode}
             onCancel={() => setEditingNode(null)}
+            onUploadProof={proofId => handleLinkProofToNode(proofId)}
           />
         ))}
     </>

--- a/imports/ui/components/SkillViewForm.jsx
+++ b/imports/ui/components/SkillViewForm.jsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import { ProofUploadButton } from './ProofUploadButton';
 
-export const SkillViewForm = ({ skilltreeId, editingNode, onCancel }) => {
+export const SkillViewForm = ({
+  skilltreeId,
+  editingNode,
+  onCancel,
+  onUploadProof
+}) => {
   const progress = Math.floor(
     (editingNode.currentNetUpvotes / editingNode.netUpvotesRequired) * 100
   );
@@ -75,6 +80,7 @@ export const SkillViewForm = ({ skilltreeId, editingNode, onCancel }) => {
               skilltreeId={skilltreeId}
               skill={editingNode.label}
               requirements={editingNode.requirements}
+              onUploadProof={onUploadProof}
             />
           </div>
         </div>

--- a/imports/ui/components/SkillViewForm.jsx
+++ b/imports/ui/components/SkillViewForm.jsx
@@ -3,9 +3,10 @@ import { ProofUploadButton } from './ProofUploadButton';
 
 export const SkillViewForm = ({ skilltreeId, editingNode, onCancel }) => {
   const progress = Math.floor(
-    (editingNode.progressXp / editingNode.xpPoints) * 100
+    (editingNode.currentNetUpvotes / editingNode.netUpvotesRequired) * 100
   );
-  const remainder = editingNode.xpPoints - editingNode.progressXp;
+  const remainder =
+    editingNode.netUpvotesRequired - editingNode.currentNetUpvotes;
 
   return (
     <div className="fixed top-0 left-0 w-screen h-screen bg-gray-600/40 flex justify-center items-center z-[1000]">
@@ -48,7 +49,7 @@ export const SkillViewForm = ({ skilltreeId, editingNode, onCancel }) => {
             htmlFor="xpPoints"
             className="block mb-2 text-sm font-medium text-emerald-700"
           >
-            XP Required:
+            Upvotes Required:
           </label>
           <div className="flex items-center gap-4">
             <div className="w-full bg-gray-200 rounded-full dark:bg-gray-700">
@@ -56,12 +57,13 @@ export const SkillViewForm = ({ skilltreeId, editingNode, onCancel }) => {
                 className="bg-yellow-600 text-xs font-medium text-blue-100 text-center p-1 leading-none rounded-full"
                 style={{ width: `${progress}%` }}
               >
-                {remainder}XP to go!
+                {remainder} upvotes to go!
               </div>
             </div>
             <div style={{ marginRight: 10 }}>
               {' '}
-              {editingNode.progressXp}/{editingNode.xpPoints}{' '}
+              {editingNode.currentNetUpvotes}/
+              {editingNode.netUpvotesRequired}{' '}
             </div>
           </div>
           <br />


### PR DESCRIPTION
- Added a `proofId` field for the skill nodes
    - when proof is uploaded, callback function will store the proofId in the node data 

- Updated XP and upvote handling
    - Progress bar now uses "upvotes required" rather than XP

- Updated schema and publications to match


- Also added xpPoints to skillTreeProgress schema - to store the user's total XP for that skillTree
   