### PR TITLE
Earn XP when node is verified and sync with proof upvotes

### DIFF
--- a/imports/api/methods/SkillTreeProgress.js
+++ b/imports/api/methods/SkillTreeProgress.js
@@ -21,11 +21,13 @@ Meteor.methods({
   async saveSkillTreeProgress(
     skillTreeId,
     progressTreeNodes = null,
-    progressTreeEdges = null
+    progressTreeEdges = null,
+    totalXp = null
   ) {
     check(skillTreeId, String);
     if (progressTreeNodes !== null) check(progressTreeNodes, [Object]);
     if (progressTreeEdges !== null) check(progressTreeEdges, [Object]);
+    if (totalXp !== null) check(totalXp, Number);
 
     //Get template tree for unsubscribed user
     const baseTree = await SkillTreeCollection.findOneAsync({
@@ -42,12 +44,15 @@ Meteor.methods({
     });
 
     if (existing) {
+      const newTotalXp = totalXp !== null ? totalXp : existing.totalXp;
+
       return await SkillTreeProgressCollection.updateAsync(
         { userId: this.userId, skillTreeId: skillTreeId },
         {
           $set: {
             skillNodes: progressTreeNodes,
-            skillEdges: progressTreeEdges
+            skillEdges: progressTreeEdges,
+            totalXp: newTotalXp
           }
         }
       );
@@ -56,7 +61,8 @@ Meteor.methods({
         userId: this.userId,
         skillTreeId,
         skillNodes: progressTreeNodes,
-        skillEdges: progressTreeEdges
+        skillEdges: progressTreeEdges,
+        totalXp: 0
       });
     }
   },

--- a/imports/api/publications/SkillTreeProgress.js
+++ b/imports/api/publications/SkillTreeProgress.js
@@ -9,6 +9,8 @@ Meteor.startup(async () => {
   const dummyProgressTree = [
     {
       userId: 123123,
+      skillTreeId: 'dummySkillTreeID',
+      totalXp: 10,
       skillNodes: [
         {
           id: '0',
@@ -32,7 +34,7 @@ Meteor.startup(async () => {
             currentNetUpvotes: 0,
             xpPoints: 10,
             requirements: 'Upload a video of yourself dribbling for 10 seconds',
-            proofId: 'testProofId'
+            proofId: 'testProof4'
           },
           position: { x: 200, y: 300 }
         },

--- a/imports/api/schemas/SkillTreeProgress.js
+++ b/imports/api/schemas/SkillTreeProgress.js
@@ -39,6 +39,12 @@ const skillDataSchema = new SimpleSchema({
     label: 'ID of the corresponding proof object for this skill',
     optional: true
   },
+  verified: {
+    type: Boolean,
+    label: 'True if the proof for this skill has been verified',
+    optional: true,
+    defaultValue: false
+  },
   requirements: {
     type: String,
     label: 'Requirements to unlock this skill',
@@ -119,9 +125,9 @@ Schemas.SkillTreeProgress = new SimpleSchema({
     type: Number,
     label: 'Unique User ID'
   },
-  communityId: {
+  skillTreeId: {
     type: Number,
-    label: 'Unique Community ID'
+    label: 'Unique Skill Tree ID'
   },
   skillNodes: {
     type: Array,
@@ -133,7 +139,7 @@ Schemas.SkillTreeProgress = new SimpleSchema({
     label: 'List of skill edges'
   },
   'skillEdges.$': skillEdgeSchema,
-  xpPoints: {
+  totalXp: {
     type: Number,
     label: 'Total XP Points earned by the user for this skilltree',
     defaultValue: 0

--- a/imports/ui/components/SkillTreeView.jsx
+++ b/imports/ui/components/SkillTreeView.jsx
@@ -8,6 +8,7 @@ import { Meteor } from 'meteor/meteor';
 
 export const SkillTreeView = ({ id, isAdmin, onBack }) => {
   useSubscribeSuspense('skilltrees');
+  const [skilltree, setSkilltree] = useState(null);
 
   // Always call useFind at the top level - but don’t necessarily use it right away
   const fallbackSkillTree = useFind(
@@ -24,7 +25,64 @@ export const SkillTreeView = ({ id, isAdmin, onBack }) => {
     [id]
   )[0];
 
-  const [skilltree, setSkilltree] = useState(null);
+  /* Fetches proof for each node and syncs netUpvotes.
+  If required netUpvotes threshold is reached, node is marked as verified and XP is earned.
+  Then updates DB and local state */
+  const syncNodeUpvotes = async () => {
+    let updatedNodes = [...skilltree.skillNodes];
+    let updatedTotalXp = skilltree.totalXp || 0;
+    let requireSyncing = false;
+
+    await Promise.all(
+      updatedNodes.map(async (node, index) => {
+        if (!node.data.verified && node.data.proofId) {
+          const proof = await Meteor.callAsync(
+            'findProofID',
+            node.data.proofId
+          );
+
+          if (proof) {
+            const netUpvotes = proof.upvotes - proof.downvotes;
+
+            // Only update if currentNetUpvotes has changed
+            if (netUpvotes != node.data.currentNetUpvotes) {
+              requireSyncing = true;
+              const updatedNode = {
+                ...node.data,
+                currentNetUpvotes: netUpvotes
+              };
+
+              if (netUpvotes >= node.data.netUpvotesRequired) {
+                console.log(
+                  `Required net upvotes reached - SkillNode Verified! "${node.data.label}", id: ${node.id}`
+                );
+                updatedNode.verified = true;
+                updatedTotalXp += node.data.xpPoints;
+                console.log(`${node.data.xpPoints} XP earned!`);
+              }
+              updatedNodes[index] = { ...node, data: updatedNode };
+            }
+          }
+        }
+      })
+    );
+
+    if (requireSyncing) {
+      Meteor.callAsync(
+        'saveSkillTreeProgress',
+        'dummySkillTreeID',
+        updatedNodes,
+        skilltree.skillEdges,
+        updatedTotalXp
+      );
+
+      setSkilltree({
+        ...skilltree,
+        skillNodes: updatedNodes,
+        totalXp: updatedTotalXp
+      });
+    }
+  };
 
   //Check if user has a saved progress
   useEffect(() => {
@@ -38,6 +96,7 @@ export const SkillTreeView = ({ id, isAdmin, onBack }) => {
         setSkilltree(fallbackSkillTree);
       }
     });
+    syncNodeUpvotes();
   }, [id, fallbackSkillTree]);
 
   if (!skilltree) {

--- a/imports/ui/components/SkillTreeView.jsx
+++ b/imports/ui/components/SkillTreeView.jsx
@@ -70,7 +70,7 @@ export const SkillTreeView = ({ id, isAdmin, onBack }) => {
     if (requireSyncing) {
       Meteor.callAsync(
         'saveSkillTreeProgress',
-        'dummySkillTreeID',
+        id,
         updatedNodes,
         skilltree.skillEdges,
         updatedTotalXp


### PR DESCRIPTION

When SkillTreeView gets rendered:
 - Sync node `netUpvotes` with proof upvotes and downvotes
 - Mark nodes as `verified: true` if netUpvote threshold is reached
 - Update `totalXp` in SkillTreeProgress when SkillNode gets verified