### PR TITLE
fix: updated setup.sh so that update cronjob sources .bash_profile

### DIFF
--- a/.deploy/setup.sh
+++ b/.deploy/setup.sh
@@ -92,7 +92,7 @@ chmod +x $HOME/pull-rebuild
 chmod +x $HOME/update
 
 # Automate pull + rebuild on changes at default branch every 5 min (cronjob) 
-(crontab -l 2>/dev/null; echo "*/5 * * * * $HOME/update") | crontab -
+(crontab -l 2>/dev/null; echo "*/5 * * * * . $HOME/.bash_profile; $HOME/update") | crontab -
 
 # Automate webserver start on server reboot
 (crontab -l; echo "@reboot . $HOME/.bash_profile; $HOME/start") | crontab -


### PR DESCRIPTION
quick fix to update setup.sh bash script so that the update cronjob sources .bash_profile to fix the pull-rebuild script called not sourcing environment variables (which is causing the restart to not use the correct hostname etc)