### PR TITLE
Update skillEditForm to set requiredUpvotes and xpPoints

### DIFF
--- a/imports/ui/components/SkillTrees/Skill/SkillEditForm.jsx
+++ b/imports/ui/components/SkillTrees/Skill/SkillEditForm.jsx
@@ -1,22 +1,7 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
+import { SliderInput } from './SliderInput';
 
 export const SkillEditForm = ({ editingNode, onSave, onCancel }) => {
-  const initialSliderValue = editingNode.xpPoints;
-  const [sliderValue, setSliderValue] = useState(initialSliderValue);
-
-  useEffect(() => {
-    setSliderValue(initialSliderValue);
-  }, [initialSliderValue]);
-
-  const handleSliderChange = e => {
-    setSliderValue(e.target.value);
-  };
-
-  const handleInputChange = e => {
-    const newValue = Math.max(0, Math.min(100, e.target.value));
-    setSliderValue(newValue);
-  };
-
   return (
     <div className="fixed top-0 left-0 w-screen h-screen bg-gray-600/40 flex justify-center items-center z-[1000]">
       <div className="bg-neutral-200 p-5 rounded-lg w-[800px]">
@@ -31,7 +16,8 @@ export const SkillEditForm = ({ editingNode, onSave, onCancel }) => {
               label: formData.get('title'),
               description: formData.get('description'),
               requirements: formData.get('requirements'),
-              xpPoints: formData.get('xpPoints')
+              xpPoints: formData.get('xpPoints'),
+              netUpvotesRequired: formData.get('upvotesRequired')
             });
           }}
         >
@@ -76,30 +62,18 @@ export const SkillEditForm = ({ editingNode, onSave, onCancel }) => {
             className="block p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300"
           />
           <br />
-          <label
-            htmlFor="xpPoints"
-            className="block mb-2 text-sm font-medium text-emerald-700"
-          >
-            XP Required:
-          </label>
-          <div className="flex items-center gap-4">
-            <input
-              name="xpPoints"
-              id="xpPoints"
-              type="range"
-              min="0"
-              max="100"
-              value={sliderValue}
-              onChange={handleSliderChange}
-              className="w-full h-1 bg-emerald-700 rounded-lg range-lg appearance-none cursor-pointer"
-            />
-            <input
-              type="number"
-              value={sliderValue}
-              onChange={handleInputChange}
-              className="block w-20 px-3 py-2 text-sm border bg-gray-50 border-gray-300 rounded-md shadow-sm"
-            />
-          </div>
+          <SliderInput
+            name="upvotesRequired"
+            displayedLabel="Upvotes Required"
+            minVal={1}
+            maxVal={100}
+          />
+          <SliderInput
+            name="xpPoints"
+            displayedLabel="XP earned"
+            minVal={1}
+            maxVal={100}
+          />
           <br />
           <div style={{ marginTop: 10 }}>
             <button type="submit">Save</button>

--- a/imports/ui/components/SkillTrees/Skill/SkillViewForm.jsx
+++ b/imports/ui/components/SkillTrees/Skill/SkillViewForm.jsx
@@ -54,7 +54,7 @@ export const SkillViewForm = ({
             htmlFor="xpPoints"
             className="block mb-2 text-sm font-medium text-emerald-700"
           >
-            Upvotes Required:
+            Upvotes Required to earn {editingNode.xpPoints} XP:
           </label>
           <div className="flex items-center gap-4">
             <div className="w-full bg-gray-200 rounded-full dark:bg-gray-700">

--- a/imports/ui/components/SkillTrees/Skill/SliderInput.jsx
+++ b/imports/ui/components/SkillTrees/Skill/SliderInput.jsx
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+
+export const SliderInput = ({ name, displayedLabel, minVal, maxVal }) => {
+  const [sliderValue, setSliderValue] = useState(minVal);
+
+  const handleSliderChange = e => {
+    setSliderValue(e.target.value);
+  };
+
+  const handleInputChange = e => {
+    const val = e.target.value;
+
+    // Allow empty string to display in UI
+    if (val === '' || val === '-') {
+      setSliderValue(null);
+      return;
+    }
+
+    const newValue = Math.max(minVal, Math.min(maxVal, val));
+    setSliderValue(newValue);
+  };
+
+  return (
+    <>
+      <label
+        htmlFor={name}
+        className="block mb-2 text-sm font-medium text-emerald-700"
+      >
+        {displayedLabel}:
+      </label>
+      <div className="flex items-center gap-4">
+        <input
+          name={name}
+          id={name}
+          type="range"
+          min={minVal}
+          max={maxVal}
+          value={sliderValue}
+          onChange={handleSliderChange}
+          className="w-full h-1 bg-emerald-700 rounded-lg range-lg appearance-none cursor-pointer"
+        />
+        <input
+          type="number"
+          value={sliderValue}
+          min={minVal}
+          max={maxVal}
+          step="1"
+          onChange={handleInputChange}
+          required
+          className="block w-20 px-3 py-2 text-sm border bg-gray-50 border-gray-300 rounded-md shadow-sm"
+        />
+      </div>
+    </>
+  );
+};


### PR DESCRIPTION
In Create SkillTree form:
- Extract the slider input logic into it's own component
- Reuse for both the `upvotesRequired` and `xpPoints` fields when creating the skillNodes
- Also set min values to 1 as per client request