### PR TITLE
St 309 verified use button on verying proofs

### DIFF
--- a/imports/api/methods/SkillTreeProgress.js
+++ b/imports/api/methods/SkillTreeProgress.js
@@ -53,25 +53,29 @@ Meteor.methods({
 
     if (existing) {
       const newTotalXp = totalXp !== null ? totalXp : existing.totalXp;
-
+      
+      // Update existing record with both user and expert roles
       return await SkillTreeProgressCollection.updateAsync(
         { userId: this.userId, skillTreeId: skillTreeId },
         {
           $set: {
             skillNodes: progressTreeNodes,
             skillEdges: progressTreeEdges,
-            totalXp: newTotalXp
+            totalXp: newTotalXp,
+            roles: ['user', 'expert']
           }
         }
       );
     } else {
+      // Create new record with both user and expert roles
+      // TEMPORARY EXPERT ROLE FOR TESTING
       return await SkillTreeProgressCollection.insertAsync({
         userId: this.userId,
         skillTreeId,
         skillNodes: progressTreeNodes,
         skillEdges: progressTreeEdges,
         totalXp: 0,
-        roles: ['user']
+        roles: ['user', 'expert']
       });
     }
   },

--- a/imports/api/methods/SkillTreeProgress.js
+++ b/imports/api/methods/SkillTreeProgress.js
@@ -53,7 +53,7 @@ Meteor.methods({
 
     if (existing) {
       const newTotalXp = totalXp !== null ? totalXp : existing.totalXp;
-      
+
       // Update existing record with both user and expert roles
       return await SkillTreeProgressCollection.updateAsync(
         { userId: this.userId, skillTreeId: skillTreeId },

--- a/imports/api/schemas/Proof.js
+++ b/imports/api/schemas/Proof.js
@@ -75,7 +75,7 @@ Schemas.Proof = new SimpleSchema({
   },
   expertVerified: {
     type: SimpleSchema.Integer,
-    label: 'number of expert that have said true for verifying this proof', 
+    label: 'number of expert that have said true for verifying this proof',
     defaultValue: 0,
     min: 0,
     optional: true

--- a/imports/api/schemas/Proof.js
+++ b/imports/api/schemas/Proof.js
@@ -72,6 +72,21 @@ Schemas.Proof = new SimpleSchema({
   },
   'downvoters.$': {
     type: String
+  },
+  expertVerified: {
+    type: SimpleSchema.Integer,
+    label: 'number of expert that have said true for verifying this proof', 
+    defaultValue: 0,
+    min: 0,
+    optional: true
+  },
+  expertVerifiers: {
+    type: Array,
+    defaultValue: [],
+    label: 'Array of expert user IDs who have verified this proof'
+  },
+  'expertVerifiers.$': {
+    type: String
   }
 });
 

--- a/imports/api/schemas/SkillTreeProgress.js
+++ b/imports/api/schemas/SkillTreeProgress.js
@@ -122,11 +122,11 @@ const skillEdgeSchema = new SimpleSchema({
 // Define the schema for the SkillTreeCollection using SimpleSchema to Schemas (for reusability)
 Schemas.SkillTreeProgress = new SimpleSchema({
   userId: {
-    type: Number,
+    type: String,
     label: 'Unique User ID'
   },
   skillTreeId: {
-    type: Number,
+    type: String,
     label: 'Unique Skill Tree ID'
   },
   skillNodes: {

--- a/imports/ui/components/Proofs/ProofsList.jsx
+++ b/imports/ui/components/Proofs/ProofsList.jsx
@@ -132,11 +132,12 @@ export const ProofsList = ({ skilltreeId, userRoles = [] }) => {
                 {/* Subskill Tag */}
                 <div className="text-sm font-bold text-black h-6 mb-2 px-2">
                   {proof.subskill || 'Subskill Placeholder'}
-                  {typeof proof.expertVerified === 'number' && proof.expertVerified > 0 && (
-                    <span className="ml-2 text-xs text-green-700 font-semibold">
-                      ✅ Verified by Expert ({proof.expertVerified})
-                    </span>
-                  )}
+                  {typeof proof.expertVerified === 'number' &&
+                    proof.expertVerified > 0 && (
+                      <span className="ml-2 text-xs text-green-700 font-semibold">
+                        ✅ Verified by Expert ({proof.expertVerified})
+                      </span>
+                    )}
                 </div>
 
                 {/* Evidence Image Preview */}
@@ -188,8 +189,7 @@ export const ProofsList = ({ skilltreeId, userRoles = [] }) => {
                       👎 Downvote ({proof.downvotes || 0})
                     </button>
                   </div>
-                  
-                  
+
                   {/* Net Upvotes Status */}
                   <div className="text-center mx-2">
                     <span>

--- a/imports/ui/components/SkillTrees/Skill/ProofUploadButton.jsx
+++ b/imports/ui/components/SkillTrees/Skill/ProofUploadButton.jsx
@@ -172,7 +172,9 @@ export const ProofUploadButton = ({
       evidenceLink: uploadResults.Location,
       verification: 0,
       skillTreeId: skilltreeId, // should eventually be a community/skillTree ID
-      subskill: skill
+      subskill: skill,
+      expertVerified: 0,
+      expertVerifiers: []
     };
     await insertProof(proof);
     // Uncomment these if you want to close the modal after submission. Should probably just link to the post view instead

--- a/imports/ui/components/SkillTrees/SkillTreeProgressExample.jsx
+++ b/imports/ui/components/SkillTrees/SkillTreeProgressExample.jsx
@@ -1,0 +1,86 @@
+import React, { Suspense } from 'react';
+import { useSubscribeSuspense } from 'meteor/communitypackages:react-router-ssr';
+import { useFind } from 'meteor/react-meteor-data/suspense';
+import { Meteor } from 'meteor/meteor';
+import { SkillTreeProgressCollection } from '/imports/api/collections/SkillTreeProgress';
+
+export const SkillTreeProgressExample = () => {
+  const currentUserId = Meteor.userId();
+  
+  // Subscribe to the current user's skill tree progress
+  useSubscribeSuspense('mySkillTreeProgress');
+  
+  // Subscribe to climbing skill tree progress for the current user
+  useSubscribeSuspense('mySkillTreeProgressByTree', 'Climbing');
+  
+  // Get all skill tree progress for the current user
+  const myProgress = useFind(
+    SkillTreeProgressCollection,
+    [{ userId: currentUserId }],
+    [currentUserId]
+  );
+  
+  // Get climbing skill tree progress for the current user
+  const climbingProgress = useFind(
+    SkillTreeProgressCollection,
+    [{ userId: currentUserId, skillTreeId: 'Climbing' }],
+    [currentUserId]
+  )[0];
+
+  return (
+    <div className="p-4">
+      <h2 className="text-2xl font-bold mb-4">Skill Tree Progress Example</h2>
+      
+      <div className="mb-6">
+        <h3 className="text-xl font-semibold mb-2">Current User ID: {currentUserId}</h3>
+        <p className="text-gray-600">This is the ID you can use with meteor.user()._id in the frontend</p>
+      </div>
+
+      <div className="mb-6">
+        <h3 className="text-xl font-semibold mb-2">All My Skill Tree Progress ({myProgress.length} entries)</h3>
+        {myProgress.map((progress, index) => (
+          <div key={index} className="border p-3 mb-2 rounded">
+            <p><strong>Skill Tree:</strong> {progress.skillTreeId}</p>
+            <p><strong>Total XP:</strong> {progress.totalXp}</p>
+            <p><strong>Roles:</strong> {progress.roles.join(', ')}</p>
+            <p><strong>Skills Completed:</strong> {progress.skillNodes.filter(node => node.data.verified).length}</p>
+          </div>
+        ))}
+      </div>
+
+      {climbingProgress && (
+        <div className="mb-6">
+          <h3 className="text-xl font-semibold mb-2">Climbing Skill Tree Progress</h3>
+          <div className="border p-3 rounded">
+            <p><strong>Skill Tree:</strong> {climbingProgress.skillTreeId}</p>
+            <p><strong>Total XP:</strong> {climbingProgress.totalXp}</p>
+            <p><strong>Roles:</strong> {climbingProgress.roles.join(', ')}</p>
+            <p><strong>Skills:</strong></p>
+            <ul className="ml-4">
+              {climbingProgress.skillNodes.map((node, index) => (
+                <li key={index} className="mb-1">
+                  <span className={node.data.verified ? 'text-green-600' : 'text-gray-600'}>
+                    {node.data.label} - {node.data.verified ? '✓ Verified' : '○ Pending'}
+                  </span>
+                  <span className="text-sm text-gray-500 ml-2">
+                    (XP: {node.data.xpPoints})
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      )}
+
+      <div className="bg-blue-50 p-4 rounded">
+        <h3 className="text-lg font-semibold mb-2">Available Publications:</h3>
+        <ul className="list-disc ml-4 space-y-1">
+          <li><code>skillTreeProgress</code> - All skill tree progress (admin)</li>
+          <li><code>mySkillTreeProgress</code> - Current user's progress</li>
+          <li><code>skillTreeProgressByTree</code> - All progress for a specific skill tree</li>
+          <li><code>mySkillTreeProgressByTree</code> - Current user's progress for a specific skill tree</li>
+        </ul>
+      </div>
+    </div>
+  );
+}; 

--- a/imports/ui/components/SkillTrees/SkillTreeProgressExample.jsx
+++ b/imports/ui/components/SkillTrees/SkillTreeProgressExample.jsx
@@ -1,4 +1,4 @@
-import React, { Suspense } from 'react';
+// import React, { Suspense } from 'react';
 import { useSubscribeSuspense } from 'meteor/communitypackages:react-router-ssr';
 import { useFind } from 'meteor/react-meteor-data/suspense';
 import { Meteor } from 'meteor/meteor';
@@ -6,20 +6,20 @@ import { SkillTreeProgressCollection } from '/imports/api/collections/SkillTreeP
 
 export const SkillTreeProgressExample = () => {
   const currentUserId = Meteor.userId();
-  
+
   // Subscribe to the current user's skill tree progress
   useSubscribeSuspense('mySkillTreeProgress');
-  
+
   // Subscribe to climbing skill tree progress for the current user
   useSubscribeSuspense('mySkillTreeProgressByTree', 'Climbing');
-  
+
   // Get all skill tree progress for the current user
   const myProgress = useFind(
     SkillTreeProgressCollection,
     [{ userId: currentUserId }],
     [currentUserId]
   );
-  
+
   // Get climbing skill tree progress for the current user
   const climbingProgress = useFind(
     SkillTreeProgressCollection,
@@ -30,37 +30,67 @@ export const SkillTreeProgressExample = () => {
   return (
     <div className="p-4">
       <h2 className="text-2xl font-bold mb-4">Skill Tree Progress Example</h2>
-      
+
       <div className="mb-6">
-        <h3 className="text-xl font-semibold mb-2">Current User ID: {currentUserId}</h3>
-        <p className="text-gray-600">This is the ID you can use with meteor.user()._id in the frontend</p>
+        <h3 className="text-xl font-semibold mb-2">
+          Current User ID: {currentUserId}
+        </h3>
+        <p className="text-gray-600">
+          This is the ID you can use with meteor.user()._id in the frontend
+        </p>
       </div>
 
       <div className="mb-6">
-        <h3 className="text-xl font-semibold mb-2">All My Skill Tree Progress ({myProgress.length} entries)</h3>
+        <h3 className="text-xl font-semibold mb-2">
+          All My Skill Tree Progress ({myProgress.length} entries)
+        </h3>
         {myProgress.map((progress, index) => (
           <div key={index} className="border p-3 mb-2 rounded">
-            <p><strong>Skill Tree:</strong> {progress.skillTreeId}</p>
-            <p><strong>Total XP:</strong> {progress.totalXp}</p>
-            <p><strong>Roles:</strong> {progress.roles.join(', ')}</p>
-            <p><strong>Skills Completed:</strong> {progress.skillNodes.filter(node => node.data.verified).length}</p>
+            <p>
+              <strong>Skill Tree:</strong> {progress.skillTreeId}
+            </p>
+            <p>
+              <strong>Total XP:</strong> {progress.totalXp}
+            </p>
+            <p>
+              <strong>Roles:</strong> {progress.roles.join(', ')}
+            </p>
+            <p>
+              <strong>Skills Completed:</strong>{' '}
+              {progress.skillNodes.filter(node => node.data.verified).length}
+            </p>
           </div>
         ))}
       </div>
 
       {climbingProgress && (
         <div className="mb-6">
-          <h3 className="text-xl font-semibold mb-2">Climbing Skill Tree Progress</h3>
+          <h3 className="text-xl font-semibold mb-2">
+            Climbing Skill Tree Progress
+          </h3>
           <div className="border p-3 rounded">
-            <p><strong>Skill Tree:</strong> {climbingProgress.skillTreeId}</p>
-            <p><strong>Total XP:</strong> {climbingProgress.totalXp}</p>
-            <p><strong>Roles:</strong> {climbingProgress.roles.join(', ')}</p>
-            <p><strong>Skills:</strong></p>
+            <p>
+              <strong>Skill Tree:</strong> {climbingProgress.skillTreeId}
+            </p>
+            <p>
+              <strong>Total XP:</strong> {climbingProgress.totalXp}
+            </p>
+            <p>
+              <strong>Roles:</strong> {climbingProgress.roles.join(', ')}
+            </p>
+            <p>
+              <strong>Skills:</strong>
+            </p>
             <ul className="ml-4">
               {climbingProgress.skillNodes.map((node, index) => (
                 <li key={index} className="mb-1">
-                  <span className={node.data.verified ? 'text-green-600' : 'text-gray-600'}>
-                    {node.data.label} - {node.data.verified ? '✓ Verified' : '○ Pending'}
+                  <span
+                    className={
+                      node.data.verified ? 'text-green-600' : 'text-gray-600'
+                    }
+                  >
+                    {node.data.label} -{' '}
+                    {node.data.verified ? '✓ Verified' : '○ Pending'}
                   </span>
                   <span className="text-sm text-gray-500 ml-2">
                     (XP: {node.data.xpPoints})
@@ -75,12 +105,22 @@ export const SkillTreeProgressExample = () => {
       <div className="bg-blue-50 p-4 rounded">
         <h3 className="text-lg font-semibold mb-2">Available Publications:</h3>
         <ul className="list-disc ml-4 space-y-1">
-          <li><code>skillTreeProgress</code> - All skill tree progress (admin)</li>
-          <li><code>mySkillTreeProgress</code> - Current user's progress</li>
-          <li><code>skillTreeProgressByTree</code> - All progress for a specific skill tree</li>
-          <li><code>mySkillTreeProgressByTree</code> - Current user's progress for a specific skill tree</li>
+          <li>
+            <code>skillTreeProgress</code> - All skill tree progress (admin)
+          </li>
+          <li>
+            <code>mySkillTreeProgress</code> - Current user's progress
+          </li>
+          <li>
+            <code>skillTreeProgressByTree</code> - All progress for a specific
+            skill tree
+          </li>
+          <li>
+            <code>mySkillTreeProgressByTree</code> - Current user's progress for
+            a specific skill tree
+          </li>
         </ul>
       </div>
     </div>
   );
-}; 
+};

--- a/imports/ui/pages/GeneralForum.jsx
+++ b/imports/ui/pages/GeneralForum.jsx
@@ -2,7 +2,7 @@ import { Meteor } from 'meteor/meteor';
 import React, { useEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { TopicList } from '../components/SkillTrees/GeneralForum/TopicListGeneralForum';
-import { NavigationMenu } from '../components/SkillTrees/NavigationMenu';
+// import { NavigationMenu } from '../components/SkillTrees/NavigationMenu';
 
 export const GeneralForum = () => {
   const { skilltreeId } = useParams();

--- a/imports/ui/pages/PendingProofs.jsx
+++ b/imports/ui/pages/PendingProofs.jsx
@@ -13,6 +13,7 @@ export const PendingProofs = () => {
   const { skilltreeId } = useParams();
 
   useSubscribeSuspense('skilltrees');
+  useSubscribeSuspense('skillTreeProgress');
   const skilltree = useFind(
     SkillTreeCollection,
     [
@@ -27,6 +28,27 @@ export const PendingProofs = () => {
     ],
     [skilltreeId]
   )[0];
+
+  // Get the current user's role in this skilltree using useFind
+  const userId = Meteor.userId();
+  const userProgress = useFind(
+    // Collection
+    require('/imports/api/collections/SkillTreeProgress').SkillTreeProgressCollection,
+    // Selector
+    [
+      { userId: { $eq: userId }, skillTreeId: { $eq: skilltreeId } },
+      { fields: { roles: 1 } }
+    ],
+    [userId, skilltreeId]
+  )[0];
+  const userRoles = userProgress?.roles || [];
+  if (userRoles.length > 0) {
+    console.log('User roles in this skilltree:', userRoles);
+  } else {
+    console.log('No roles found for user in this skilltree.');
+  }
+
+  // ...existing code...
 
   if (!skilltree) return <div>Skill Tree not found</div>;
 
@@ -45,7 +67,7 @@ export const PendingProofs = () => {
         </button>
         {/* Responsive container for ProofsList */}
         <Suspense fallback={<Fallback msg={'Loading proofs...'} />}>
-          <ProofsList skilltreeId={skilltreeId} />
+          <ProofsList skilltreeId={skilltreeId} userRoles={userRoles} />
         </Suspense>
       </div>
     </>

--- a/imports/ui/pages/PendingProofs.jsx
+++ b/imports/ui/pages/PendingProofs.jsx
@@ -1,5 +1,6 @@
 import React, { Suspense } from 'react';
 import { Helmet } from 'react-helmet';
+import { Meteor } from 'meteor/meteor';
 
 // JSX UI
 import { useSubscribeSuspense } from 'meteor/communitypackages:react-router-ssr';
@@ -33,7 +34,8 @@ export const PendingProofs = () => {
   const userId = Meteor.userId();
   const userProgress = useFind(
     // Collection
-    require('/imports/api/collections/SkillTreeProgress').SkillTreeProgressCollection,
+    require('/imports/api/collections/SkillTreeProgress')
+      .SkillTreeProgressCollection,
     // Selector
     [
       { userId: { $eq: userId }, skillTreeId: { $eq: skilltreeId } },

--- a/imports/ui/pages/PendingProofs.jsx
+++ b/imports/ui/pages/PendingProofs.jsx
@@ -10,6 +10,8 @@ import { SkillTreeCollection } from '/imports/api/collections/SkillTree';
 import { Fallback } from '../components/SiteFrame/Fallback';
 import { ProofsList } from '../components/Proofs/ProofsList';
 
+import { SkillTreeProgressCollection } from '/imports/api/collections/SkillTreeProgress';
+
 export const PendingProofs = () => {
   const { skilltreeId } = useParams();
 
@@ -33,10 +35,7 @@ export const PendingProofs = () => {
   // Get the current user's role in this skilltree using useFind
   const userId = Meteor.userId();
   const userProgress = useFind(
-    // Collection
-    require('/imports/api/collections/SkillTreeProgress')
-      .SkillTreeProgressCollection,
-    // Selector
+    SkillTreeProgressCollection,
     [
       { userId: { $eq: userId }, skillTreeId: { $eq: skilltreeId } },
       { fields: { roles: 1 } }


### PR DESCRIPTION
NOTE: In the event of having to make quick fixes or under limited time, just provide a quick summary. Delete the rest.

# Summary

The implementation of a verify button, that only shows to a user with the expert role in the specific tree. Once this button is clicked, it shows on the proof for all users, that an expert has "verified" the proof.
FE and BE have been implemented for this.
For testing, temporarily, a user when subscribing, will be assigned both user and expert role. This will be changed just before merging




# Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Please describe in detail how you tested your changes (i.e., User Testing, Unit Testing)
Provide instructions so we can reproduce.

Click the subscribe button as a user, view the pending proofs page, and click verify, to test that it works.
(atm when subscribing, a user gets assigned both user and expert, in order to allow testing)



# Checklist:
- [yes ] My code follows the style guidelines of this project
- [yes ] I have performed a self-review of my code
- [yes ] I have commented my code, specifically in difficult-to-understand code areas
- [ N/A] I have made corresponding changes to the documentation
- [yes ] My changes generate no new warnings
- [ yes] I have conducted tests that prove my fix is effective or that my feature works
- [ yes] Any dependent changes have been carefully merged and published in downstream modules

