### PR TITLE
Fix 'flicker' issue on client side navigation for Dashboard SkillTrees Fallback  

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,9 @@ tests/
 >  import { FiLock } from '@react-icons/all-files/fi/FiLock';`
 >  ``````
 
+> [!TIP]
+> _Non useFind, datetime (timezone) or modified data (sorting etc) fetches from the database that gets loaded directly on the page should opt out of SSR such as the DashboardSkillTrees (sort mismatch issue) and ProofsList (datetime timezone mismatch) etc._
+
 ## Deployment
 ### Ubuntu 24.04 LTS (Noble)
 > [!NOTE]

--- a/imports/ui/components/Dashboard/LoadingState.jsx
+++ b/imports/ui/components/Dashboard/LoadingState.jsx
@@ -10,14 +10,14 @@ export const DashboardLoadingState = () => {
           </p>
         </div>
         <div className="flex items-center">
-          <span className="animate-pulse h-4 bg-gray-200 rounded w-48"></span>
+          <span className="animate-pulse fadeInEffect h-4 bg-gray-200 rounded w-48"></span>
         </div>
       </div>
       <div className="bg-white rounded-xl border border-gray-100 p-4 lg:p-6">
         <div className="space-y-4">
           {[1, 2].map(section => (
             <div key={section}>
-              <div className="animate-pulse grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+              <div className="animate-pulse fadeInEffect grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
                 {[1, 2, 3].map(item => (
                   <div key={item} className="bg-gray-200 rounded-xl h-53"></div>
                 ))}

--- a/imports/ui/pages/PendingProofs.jsx
+++ b/imports/ui/pages/PendingProofs.jsx
@@ -6,7 +6,6 @@ import { Meteor } from 'meteor/meteor';
 import { useSubscribe, useFind } from 'meteor/react-meteor-data/suspense';
 import { useParams } from 'react-router-dom';
 import { SkillTreeCollection } from '/imports/api/collections/SkillTree';
-import { DashboardLoadingState } from '../components/Dashboard/LoadingState';
 import { ProofsList } from '../components/Proofs/ProofsList';
 import { NavigationMenu } from '../components/SkillTrees/NavigationMenu';
 
@@ -60,7 +59,7 @@ export const PendingProofs = () => {
       <div className="p-2">
         <NavigationMenu id={skilltreeId} />
         {/* Responsive container for ProofsList */}
-        <Suspense fallback={<DashboardLoadingState />}>
+        <Suspense>
           <ProofsList skilltreeId={skilltreeId} />
         </Suspense>
       </div>


### PR DESCRIPTION
Quick fix to add back fadeIn effect for Dashboard SkillTrees Fallback to smooth out the 'flicker' on client side navigation and updated README.md on SSR info