### PR TITLE
Fix deployment restart race condition

### DIFF
--- a/.deploy/restart.sh
+++ b/.deploy/restart.sh
@@ -3,4 +3,5 @@
 # Script to restart (stop + start) reverse proxy & webserver in the screen session
 
 ./stop || ./stop.sh # 'Stop' reverse proxy & webserver script
+sleep 1 # Need to give some time to stop to avoid race condition
 ./start || ./start.sh # 'Start' reverse proxy & webserver script


### PR DESCRIPTION
Quick fix to add 1 second delay between stop and start script in restart.sh to avoid race condition that sometime causes the reverse proxy server to not start