### PR TITLE
St 431 fix skilltree save

### DIFF
--- a/imports/api/methods/SkillTree.js
+++ b/imports/api/methods/SkillTree.js
@@ -45,20 +45,23 @@ Meteor.methods({
     return await SkillTreeCollection.insertAsync(processedSkillTree);
   },
 
-  'skilltrees.update'(skilltreeId, skilltree) {
+  async 'skilltrees.update'(skilltreeId, skilltree) {
     // Schemas.SkillTree.validate(skilltree);
 
-    if (!SkillTreeCollection.findOne(skilltreeId)) {
+    if (!SkillTreeCollection.findOneAsync(skilltreeId)) {
       throw new Meteor.Error('skilltree-not-found', 'SkillTree not found');
     }
 
+    // Remove _id if present
+    const { _id, ...rest } = skilltree;
+
     // Add updatedAt timestamp
     const updateData = {
-      ...skilltree,
+      ...rest,
       updatedAt: new Date()
     };
 
-    return SkillTreeCollection.update(skilltreeId, { $set: updateData });
+    return SkillTreeCollection.updateAsync(skilltreeId, { $set: updateData });
   },
 
   'skilltrees.remove'(skilltreeId) {

--- a/imports/ui/components/SkillTrees/SkillTree.jsx
+++ b/imports/ui/components/SkillTrees/SkillTree.jsx
@@ -108,7 +108,7 @@ export const SkillTreeLogic = ({
 
   const initialEdges = savedEdges ?? [];
 
-  const idRef = useRef(1);
+  const idRef = useRef(initialNodes.length);
   const getId = () => `${idRef.current++}`;
   const nodeOrigin = [0.5, 0];
 

--- a/imports/ui/pages/CreateSkillTree.jsx
+++ b/imports/ui/pages/CreateSkillTree.jsx
@@ -9,12 +9,13 @@ import { AuthContext } from '/imports/utils/contexts/AuthContext';
 import { CreateTreeForm } from '../components/SkillTrees/CreateTreeForm';
 import { SkillTreeEdit } from '../components/SkillTrees/SkillTree';
 import { ToastContainer, toast, Flip } from 'react-toastify';
-import { useNavigate } from 'react-router-dom';
+import { update } from 'lodash';
+//import { useNavigate } from 'react-router-dom';
 
 export const CreateSkillTree = () => {
   //Current user id logged in
   const userId = useContext(AuthContext); // Reactive when value changes
-  const navigate = useNavigate();
+  //const navigate = useNavigate();
   const [showAddDetailsForm, setShowAddDetailsForm] = useState(true);
   const [showAddSkillsForm, setShowAddSkillsForm] = useState(false);
   const [skillTree, setSkillTree] = useState({
@@ -89,11 +90,17 @@ export const CreateSkillTree = () => {
 
   const handleSaveSkillTree = async skilltreeToSave => {
     try {
-      //Insert the new skilltree into the collection
-      const skillTreeId = await Meteor.callAsync(
-        'skilltrees.insert',
-        skilltreeToSave
-      );
+      let skillTreeId = skillTree._id;
+
+      if (!skillTreeId) {
+        // First save: insert new SkillTree
+        const newSkillTreeId = await Meteor.callAsync(
+          'skilltrees.insert',
+          skilltreeToSave
+        );
+        // Store the new ID
+        setSkillTree(prev => ({ ...prev, _id: newSkillTreeId })); 
+        skillTreeId = newSkillTreeId;
 
       //Update the owner's created communities list
       await Meteor.callAsync('updateCreatedCommunities', skillTreeId);
@@ -107,21 +114,24 @@ export const CreateSkillTree = () => {
 
       };
 
-      await Meteor.callAsync(
-        'updateSkillTreeProgress',
-        skillTreeId,
-        userId,
-        updateOperation
-      );
+      toast.success('Successfully created SkillTree!');
+      } else {
+        // Subsequent saves: update existing SkillTree
+        const { _id, ...updateData } = skilltreeToSave; // Exclude _id from update data
+        await Meteor.callAsync('skilltrees.update', skillTreeId, updateData);
 
-      navigate('/dashboard', { state: { showSkillTreeCreatedToast: true } });
+        setSkillTree(prev => ({
+          ...prev,
+          ...updateData,
+          updatedAt: new Date()
+        }));
 
-      console.log('Skill Tree saved successfully');
+        toast.success('SkillTree updated!');
+      }
     } catch (error) {
       console.error('Error saving skill tree:', error);
+      toast.error('Error saving SkillTree!');
     }
-    // Show confirmation popup
-    toast.success('Successfully created SkillTree!');
   };
 
   return (

--- a/imports/ui/pages/CreateSkillTree.jsx
+++ b/imports/ui/pages/CreateSkillTree.jsx
@@ -89,50 +89,56 @@ export const CreateSkillTree = () => {
   };
 
   const handleSaveSkillTree = async skilltreeToSave => {
-    try {
-      let skillTreeId = skillTree._id;
+  console.log("save clicked");
+  console.log("Data to save:", skilltreeToSave);
+  
+  try {
+    let skillTreeId = skillTree._id;
 
-      if (!skillTreeId) {
-        // First save: insert new SkillTree
-        const newSkillTreeId = await Meteor.callAsync(
-          'skilltrees.insert',
-          skilltreeToSave
-        );
-        // Store the new ID
-        setSkillTree(prev => ({ ...prev, _id: newSkillTreeId })); 
-        skillTreeId = newSkillTreeId;
+    if (!skillTreeId) {
+      // First save: insert new SkillTree
+      const newSkillTreeId = await Meteor.callAsync(
+        'skilltrees.insert',
+        skilltreeToSave
+      );
+      // Store the new ID
+      setSkillTree(prev => ({ ...prev, _id: newSkillTreeId }));
+      skillTreeId = newSkillTreeId;
 
-      //Update the owner's created communities list
+     //Update the owner's created communities list
       await Meteor.callAsync('updateCreatedCommunities', skillTreeId);
       //Update the owner's subscribed communities list
       await Meteor.callAsync('updateSubscribedCommunities', skillTreeId);
       //Add skilltree progress --> this will execute the else condition
       await Meteor.callAsync('saveSubscription', skillTreeId);
-      //Add admin role to skilltree progression
-      const updateOperation = {
-        $addToSet: { roles: 'admin' }
-
-      };
-
+      
+      // Add admin role
+      const updateOperation = { $addToSet: { roles: 'admin' } };
       toast.success('Successfully created SkillTree!');
-      } else {
-        // Subsequent saves: update existing SkillTree
-        const { _id, ...updateData } = skilltreeToSave; // Exclude _id from update data
-        await Meteor.callAsync('skilltrees.update', skillTreeId, updateData);
+    } else {
+      // Subsequent saves: update existing SkillTree
+      const updateData = { ...skilltreeToSave };      
+      console.log("Updating with data:", updateData);
+      
+      await Meteor.callAsync('skilltrees.update', skillTreeId, updateData);
 
-        setSkillTree(prev => ({
-          ...prev,
-          ...updateData,
-          updatedAt: new Date()
-        }));
-
-        toast.success('SkillTree updated!');
-      }
-    } catch (error) {
-      console.error('Error saving skill tree:', error);
-      toast.error('Error saving SkillTree!');
+      // Update local state
+      setSkillTree(prev => ({
+        ...prev,
+        ...updateData,
+        updatedAt: new Date()
+      }));
+      // await Meteor.callAsync('updateCreatedCommunities', skillTreeId);
+      // await Meteor.callAsync('updateSubscribedCommunities', skillTreeId);
+      await Meteor.callAsync('saveSubscription', skillTreeId);
+      console.log("SkillTree updated successfully");
+      toast.success('SkillTree updated!');
     }
-  };
+  } catch (error) {
+    console.error('Error saving skill tree:', error);
+    toast.error('Error saving SkillTree!');
+  }
+};
 
   return (
     <>
@@ -155,6 +161,8 @@ export const CreateSkillTree = () => {
         {/* Conditionally render add skills form, Only pass nodes and edges if they exist*/}
         {showAddSkillsForm && skillTree.skillNodes.length > 0 && (
           <>
+            {console.log("Skilltree found and loaded")}
+            {/* {console.log(skilltreeToSave)} */}
             <SkillTreeEdit
               isAdmin={true}
               onSave={updateNodesAndEdges}
@@ -166,6 +174,8 @@ export const CreateSkillTree = () => {
         )}
         {showAddSkillsForm && skillTree.skillNodes.length == 0 && (
           <>
+            {console.log("0 Skill tree found")}
+            {/* {console.log(skilltreeToSave)} */}
             <SkillTreeEdit
               isAdmin={true}
               onSave={updateNodesAndEdges}

--- a/imports/ui/pages/CreateSkillTree.jsx
+++ b/imports/ui/pages/CreateSkillTree.jsx
@@ -9,11 +9,12 @@ import { AuthContext } from '/imports/utils/contexts/AuthContext';
 import { CreateTreeForm } from '../components/SkillTrees/CreateTreeForm';
 import { SkillTreeEdit } from '../components/SkillTrees/SkillTree';
 import { ToastContainer, toast, Flip } from 'react-toastify';
+import { useNavigate } from 'react-router-dom';
 
 export const CreateSkillTree = () => {
   //Current user id logged in
   const userId = useContext(AuthContext); // Reactive when value changes
-
+  const navigate = useNavigate();
   const [showAddDetailsForm, setShowAddDetailsForm] = useState(true);
   const [showAddSkillsForm, setShowAddSkillsForm] = useState(false);
   const [skillTree, setSkillTree] = useState({
@@ -103,6 +104,7 @@ export const CreateSkillTree = () => {
       //Add admin role to skilltree progression
       const updateOperation = {
         $addToSet: { roles: 'admin' }
+
       };
 
       await Meteor.callAsync(
@@ -111,6 +113,8 @@ export const CreateSkillTree = () => {
         userId,
         updateOperation
       );
+
+      navigate('/dashboard', { state: { showSkillTreeCreatedToast: true } });
 
       console.log('Skill Tree saved successfully');
     } catch (error) {


### PR DESCRIPTION
NOTE: In the event of having to make quick fixes or under limited time, just provide a quick summary. Delete the rest.

# Summary

-
- Fixed bug where saving would create multiple identical trees
- Fixed bug where nodes and edges were not updated after save
- Fixed bug where after initial save, created nodes caused errors and deleted previous nodes
- Refactored save button to direct to homepage when creating skilltree (logic exists but commented out just until uat is complete)


# Related Issues:

Bug fixes



# Type of change
Bug fix
# How Has This Been Tested?
User testing


