### PR TITLE
fix bug: able to set future dob

### DIFF
--- a/imports/ui/components/SignUp/SignUpStep3.jsx
+++ b/imports/ui/components/SignUp/SignUpStep3.jsx
@@ -159,6 +159,7 @@ const Step3 = () => {
                 value={formData.profile.dateOfBirth || ''}
                 onChange={handleChange}
                 required
+                max={new Date().toISOString().split('T')[0]}
                 className={`w-full px-4 py-3 rounded-full border border-gray-300 outline-none text-black bg-white ${errors.dateOfBirth ? 'border-red-500' : 'border-gray-300'}`}
               />
 


### PR DESCRIPTION


NOTE: In the event of having to make quick fixes or under limited time, just provide a quick summary. Delete the rest.

Summary
Please include a summary of the changes (dot points)

Added max attribute to the Date of Birth input field.
Ensures users cannot select a future date as their DOB.
Uses today’s date (new Date().toISOString().split('T')[0]) as the maximum allowed value.

Related Issues:
Fixes #173 




