### PR TITLE
Refactor saveSubscription Meteor method logic to fix nodes and edges …

### DIFF
--- a/imports/api/methods/Subscriptions.js
+++ b/imports/api/methods/Subscriptions.js
@@ -1,7 +1,7 @@
-import { Meteor } from 'meteor/meteor';
-import { SubscriptionsCollection } from '/imports/api/collections/Subscriptions';
-import { SkillTreeCollection } from '/imports/api/collections/SkillTree';
 import { check } from 'meteor/check';
+import { Meteor } from 'meteor/meteor';
+import { SkillTreeCollection } from '/imports/api/collections/SkillTree';
+import { SubscriptionsCollection } from '/imports/api/collections/Subscriptions';
 
 // TODO: POSTING A PROOF AUTO-SUBSCRIBES YOU FOR SOME REASON BUT THIS DOESN'T UPDATE ON THE SUBSCRIBE BUTTON
 Meteor.methods({
@@ -25,6 +25,10 @@ Meteor.methods({
     progressTreeEdges = null,
     totalXp = null
   ) {
+    console.log(
+      'saveSubscription called, progressTreeNodes at start: ',
+      progressTreeNodes
+    );
     check(skillTreeId, String);
     if (progressTreeNodes !== null) check(progressTreeNodes, [Object]);
     if (progressTreeEdges !== null) check(progressTreeEdges, [Object]);
@@ -34,10 +38,6 @@ Meteor.methods({
     const baseTree = await SkillTreeCollection.findOneAsync({
       _id: skillTreeId
     });
-    if (progressTreeNodes == null && progressTreeEdges == null) {
-      progressTreeNodes = baseTree.skillNodes;
-      progressTreeEdges = baseTree.skillEdges;
-    }
 
     const existing = await SubscriptionsCollection.findOneAsync({
       userId: this.userId,
@@ -45,23 +45,32 @@ Meteor.methods({
     });
 
     if (existing) {
+      console.log('updating existing subscription');
       const newTotalXp = totalXp !== null ? totalXp : existing.totalXp;
+
+      const updated = { active: true, totalXp: newTotalXp };
+      if (progressTreeNodes) {
+        updated.skillNodes = progressTreeNodes;
+      }
+      if (progressTreeEdges) {
+        updated.skillEdges = progressTreeEdges;
+      }
 
       return await SubscriptionsCollection.updateAsync(
         { userId: this.userId, skillTreeId: skillTreeId },
         {
-          $set: {
-            skillNodes: progressTreeNodes,
-            skillEdges: progressTreeEdges,
-            active: true,
-            totalXp: newTotalXp
-          },
+          $set: updated,
           $addToSet: {
             roles: { $each: ['user', 'expert'] }
           }
         }
       );
     } else {
+      console.log('creating new subscription');
+      if (progressTreeNodes == null && progressTreeEdges == null) {
+        progressTreeNodes = baseTree.skillNodes;
+        progressTreeEdges = baseTree.skillEdges;
+      }
       return await SubscriptionsCollection.insertAsync({
         userId: this.userId,
         skillTreeId,
@@ -118,6 +127,7 @@ Meteor.methods({
   },
 
   async updateSkillTreeProgress(skillTreeId, userId, updateOperation) {
+    console.log('updateSkillTreeProgress called');
     check(skillTreeId, String);
     check(userId, String);
     check(updateOperation, Object);


### PR DESCRIPTION
…being reset when an existing subscription is saved

NOTE: In the event of having to make quick fixes or under limited time, just provide a quick summary. Delete the rest.

# Summary

Please include a summary of the changes (dot points)
- Moved the logic for defaulting progressTreeNodes and progressTreeEdges to the values of the base tree so that it only runs if creating a new subscription rather than editing an existing subscription. Also split them up so that progressTreeNodes can be passed as a parameter without also passing progressTreeEdges and vice versa

# Related Issues:

_Fixes #(Issue Number)_
ST-412


# Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change involves a documentation update

# How Has This Been Tested?
Please describe in detail how you tested your changes (i.e., User Testing, Unit Testing)
Provide instructions so we can reproduce.

- [X] Manual testing to see if the bug in the title is fixed: subscribe -> post -> upvote -> unsubscribe -> subscribe -> refresh -> check modal progress
- [X] Testing creating a new skilltree to see if it works as expected


# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, specifically in difficult-to-understand code areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have conducted tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been carefully merged and published in downstream modules

