### PR TITLE
St 431 fix skilltree save

### DIFF
--- a/imports/api/methods/SkillTree.js
+++ b/imports/api/methods/SkillTree.js
@@ -45,23 +45,23 @@ Meteor.methods({
     return await SkillTreeCollection.insertAsync(processedSkillTree);
   },
 
-  'skilltrees.update'(skilltreeId, skilltree) {
+  async 'skilltrees.update'(skilltreeId, skilltree) {
     // Schemas.SkillTree.validate(skilltree);
 
-    if (!SkillTreeCollection.findOne(skilltreeId)) {
-      throw new Meteor.Error(
-        'skilltree-not-found',
-        'SkillTree not found when updating SkillTree'
-      );
+    if (!SkillTreeCollection.findOneAsync(skilltreeId)) {
+      throw new Meteor.Error('skilltree-not-found', 'SkillTree not found');
     }
+
+    // Remove _id if present
+    const { _id, ...rest } = skilltree;
 
     // Add updatedAt timestamp
     const updateData = {
-      ...skilltree,
+      ...rest,
       updatedAt: new Date()
     };
 
-    return SkillTreeCollection.update(skilltreeId, { $set: updateData });
+    return SkillTreeCollection.updateAsync(skilltreeId, { $set: updateData });
   },
 
   'skilltrees.remove'(skilltreeId) {

--- a/imports/api/methods/SkillTree.js
+++ b/imports/api/methods/SkillTree.js
@@ -54,6 +54,7 @@ Meteor.methods({
 
     // Remove _id if present
     const { _id, ...rest } = skilltree;
+    void _id; // explicitly mark unused for linter to pass
 
     // Add updatedAt timestamp
     const updateData = {

--- a/imports/api/publications/SkillTree.js
+++ b/imports/api/publications/SkillTree.js
@@ -24,10 +24,9 @@ Meteor.startup(async () => {
           data: {
             label: 'root',
             description: 'root',
-            netUpvotesRequired: null,
-            currentUpvotes: null,
             requirements: 'root',
-            xpPoints: null
+            xpPoints: null,
+            children: ['7', '4', '3']
           },
           position: { x: 0, y: 0 }
         },
@@ -37,10 +36,12 @@ Meteor.startup(async () => {
           data: {
             label: 'basic dribbling 🏀',
             description: 'Learn how to dribble the basketball effectively.',
-            requirements: 'Upload a video of yourself dribbling for 10 seconds',
             netUpvotesRequired: 10,
-            currentNetUpvotes: 5,
-            xpPoints: 10
+            currentNetUpvotes: 0,
+            xpPoints: 10,
+            requirements: 'Upload a video of yourself dribbling for 10 seconds',
+            proofId: 'testProofId',
+            children: []
           },
           position: { x: 200, y: 300 }
         },
@@ -50,24 +51,26 @@ Meteor.startup(async () => {
           data: {
             label: 'Layup 🏃‍♂️',
             description:
-              ' A close-range shot taken by driving toward the basket and laying the ball off the backboard.',
+              'A close-range shot taken by driving toward the basket and laying the ball off the backboard.',
             requirements: 'Upload a video of yourself',
             netUpvotesRequired: 10,
             currentNetUpvotes: 0,
-            xpPoints: 10
+            xpPoints: 10,
+            children: ['1']
           },
           position: { x: 200, y: 200 }
         },
         {
           id: '3',
-          type: 'view-node-locked',
+          type: 'view-node-unlocked',
           data: {
             label: 'Spin Move 😵',
             description: 'Learn how to do a spin move.',
             requirements: 'Upload a video of yourself',
             netUpvotesRequired: 15,
-            currentNetUpvotes: 3,
-            xpPoints: 15
+            currentNetUpvotes: 0,
+            xpPoints: 15,
+            children: ['2']
           },
           position: { x: 200, y: 100 }
         },
@@ -81,7 +84,8 @@ Meteor.startup(async () => {
               'Upload a video of yourself doing the illinois agility test',
             netUpvotesRequired: 10,
             currentNetUpvotes: 0,
-            xpPoints: 50
+            xpPoints: 10,
+            children: []
           },
           position: { x: 0, y: 100 }
         },
@@ -94,7 +98,8 @@ Meteor.startup(async () => {
             requirements: 'Upload a video of yourself',
             netUpvotesRequired: 10,
             currentNetUpvotes: 0,
-            xpPoints: 20
+            xpPoints: 10,
+            children: []
           },
           position: { x: -200, y: 300 }
         },
@@ -107,7 +112,8 @@ Meteor.startup(async () => {
             requirements: 'Upload a video of yourself',
             netUpvotesRequired: 10,
             currentNetUpvotes: 0,
-            xpPoints: 20
+            xpPoints: 10,
+            children: ['5']
           },
           position: { x: -150, y: 200 }
         },
@@ -118,9 +124,10 @@ Meteor.startup(async () => {
             label: 'Three Pointers 💧',
             description: 'Learn how to do a spin move.',
             requirements: 'Upload a video of yourself',
-            netUpvotesRequired: 1,
+            netUpvotesRequired: 10,
             currentNetUpvotes: 0,
-            xpPoints: 20
+            xpPoints: 10,
+            children: ['6', '8']
           },
           position: { x: -250, y: 100 }
         },
@@ -133,7 +140,8 @@ Meteor.startup(async () => {
             requirements: 'Upload a video of yourself',
             netUpvotesRequired: 10,
             currentNetUpvotes: 0,
-            xpPoints: 20
+            xpPoints: 10,
+            children: ['5']
           },
           position: { x: -350, y: 200 }
         }
@@ -164,7 +172,19 @@ Meteor.startup(async () => {
       tags: ['football', 'soccer', 'sports'],
       skillNodes: [
         {
-          id: 'pass',
+          id: '0',
+          type: 'root',
+          data: {
+            label: 'root',
+            description: 'root',
+            requirements: 'root',
+            xpPoints: null,
+            children: ['1', '2', '3']
+          },
+          position: { x: 0, y: 0 }
+        },
+        {
+          id: '1',
           type: 'view-node-unlocked',
           data: {
             label: 'Passing',
@@ -173,12 +193,13 @@ Meteor.startup(async () => {
               'Upload a video of yourself passing back and forth 3 times with another player',
             netUpvotesRequired: 10,
             currentNetUpvotes: 0,
-            xpPoints: 10
+            xpPoints: 10,
+            children: []
           },
           position: { x: 300, y: 100 }
         },
         {
-          id: 'shoot',
+          id: '2',
           type: 'view-node-locked',
           data: {
             label: 'Shooting',
@@ -186,12 +207,13 @@ Meteor.startup(async () => {
             requirements: 'Upload a video of yourself scoring a goal',
             netUpvotesRequired: 10,
             currentNetUpvotes: 0,
-            xpPoints: 30
+            xpPoints: 30,
+            children: []
           },
           position: { x: 100, y: 250 }
         },
         {
-          id: 'goalkeep',
+          id: '3',
           type: 'view-node-locked',
           data: {
             label: 'Goalkeeping',
@@ -199,14 +221,16 @@ Meteor.startup(async () => {
             requirements: 'Upload a video of yourself making a save',
             netUpvotesRequired: 10,
             currentNetUpvotes: 0,
-            xpPoints: 50
+            xpPoints: 50,
+            children: []
           },
           position: { x: 500, y: 350 }
         }
       ],
       skillEdges: [
-        { id: 'e1', source: 'pass', target: 'shoot' },
-        { id: 'e2', source: 'shoot', target: 'goalkeep' }
+        { id: 'e1', source: '0', target: '1' },
+        { id: 'e2', source: '0', target: '2' },
+        { id: 'e3', source: '0', target: '3' }
       ],
       admins: ['soccerpro'],
       subscribers: ['fanX', 'fanY']
@@ -228,14 +252,13 @@ Meteor.startup(async () => {
             label: 'root',
             description: 'root',
             requirements: 'root',
-            netUpvotesRequired: null,
-            currentNetUpvotes: null,
-            xpPoints: null
+            xpPoints: null,
+            children: ['1']
           },
-          position: { x: 0, y: 0 }
+          position: { x: 300, y: 0 }
         },
         {
-          id: 'bat',
+          id: '1',
           type: 'view-node-locked',
           data: {
             label: 'Batting',
@@ -243,12 +266,13 @@ Meteor.startup(async () => {
             requirements: 'Upload a video of yourself batting for 10 balls',
             netUpvotesRequired: 10,
             currentNetUpvotes: 0,
-            xpPoints: 15
+            xpPoints: 15,
+            children: ['']
           },
           position: { x: 100, y: 75 }
         },
         {
-          id: 'bowl',
+          id: '2',
           type: 'view-node-locked',
           data: {
             label: 'Bowling',
@@ -256,12 +280,13 @@ Meteor.startup(async () => {
             requirements: 'Upload a video of yourself bowling 10 balls',
             netUpvotesRequired: 10,
             currentNetUpvotes: 0,
-            xpPoints: 25
+            xpPoints: 25,
+            children: []
           },
           position: { x: 300, y: 175 }
         },
         {
-          id: 'field',
+          id: '3',
           type: 'view-node-locked',
           data: {
             label: 'Fielding',
@@ -269,15 +294,16 @@ Meteor.startup(async () => {
             requirements: 'Upload a video of yourself fielding and catching',
             netUpvotesRequired: 10,
             currentNetUpvotes: 0,
-            xpPoints: 35
+            xpPoints: 35,
+            children: []
           },
           position: { x: 500, y: 275 }
         }
       ],
       skillEdges: [
-        { id: 'e1', source: '0', target: 'bat' },
-        { id: 'e2', source: 'bat', target: 'bowl' },
-        { id: 'e3', source: 'bowl', target: 'field' }
+        { id: 'e1', source: '0', target: '1' },
+        { id: 'e2', source: '0', target: '2' },
+        { id: 'e3', source: '0', target: '3' },
       ],
       admins: ['cricketpro'],
       subscribers: ['user1', 'user2']
@@ -293,7 +319,19 @@ Meteor.startup(async () => {
       tags: ['tennis', 'racket', 'sports'],
       skillNodes: [
         {
-          id: 'serve',
+          id: '0',
+          type: 'root',
+          data: {
+            label: 'root',
+            description: 'root',
+            requirements: 'root',
+            xpPoints: null,
+            children: ['1', '2']
+          },
+          position: { x: 0, y: 0 }
+        },
+        {
+          id: '1',
           type: 'view-node-unlocked',
           data: {
             label: 'Serving',
@@ -301,12 +339,13 @@ Meteor.startup(async () => {
             requirements: 'Upload a video of yourself serving 5 times',
             netUpvotesRequired: 10,
             currentNetUpvotes: 0,
-            xpPoints: 20
+            xpPoints: 20,
+            children: ['3']
           },
           position: { x: 300, y: 100 }
         },
         {
-          id: 'rally',
+          id: '2',
           type: 'view-node-locked',
           data: {
             label: 'Rally Techniques',
@@ -315,12 +354,13 @@ Meteor.startup(async () => {
               'Upload a video of yourself making a rally with at least 10 hits',
             netUpvotesRequired: 10,
             currentNetUpvotes: 0,
-            xpPoints: 30
+            xpPoints: 30,
+            children: []
           },
-          position: { x: 300, y: 200 }
+          position: { x: 100, y: 200 }
         },
         {
-          id: 'serve-and-volley',
+          id: '3',
           type: 'view-node-locked',
           data: {
             label: 'Serve and Volley',
@@ -329,14 +369,16 @@ Meteor.startup(async () => {
               'Upload a video of yourself winning a point with a serve and volley',
             netUpvotesRequired: 10,
             currentNetUpvotes: 0,
-            xpPoints: 75
+            xpPoints: 75,
+            children: []
           },
-          position: { x: 300, y: 300 }
+          position: { x: 300, y: 200 }
         }
       ],
       skillEdges: [
-        { id: 'e1', source: 'serve', target: 'rally' },
-        { id: 'e2', source: 'rally', target: 'serve-and-volley' }
+        { id: 'e1', source: '0', target: '1' },
+        { id: 'e2', source: '0', target: '2' },
+        { id: 'e3', source: '1', target: '3' }
       ],
       admins: ['tennispro'],
       subscribers: ['playerZ', 'coachY']
@@ -352,7 +394,19 @@ Meteor.startup(async () => {
       tags: ['climbing', 'outdoor', 'sports'],
       skillNodes: [
         {
-          id: 'bouldering',
+          id: '0',
+          type: 'root',
+          data: {
+            label: 'root',
+            description: 'root',
+            requirements: 'root',
+            xpPoints: null,
+            children: ['1','2']
+          },
+          position: { x: 0, y: 0 }
+        },
+        {
+          id: '1',
           type: 'view-node-unlocked',
           data: {
             label: 'Bouldering',
@@ -360,12 +414,13 @@ Meteor.startup(async () => {
             requirements: 'Upload a video of yourself bouldering for 5 minutes',
             netUpvotesRequired: 10,
             currentNetUpvotes: 0,
-            xpPoints: 20
+            xpPoints: 20,
+            children: []
           },
-          position: { x: 300, y: 100 }
+          position: { x: 100, y: 100 }
         },
         {
-          id: 'climbing-techniques',
+          id: '2',
           type: 'view-node-locked',
           data: {
             label: 'Climbing Techniques',
@@ -374,12 +429,13 @@ Meteor.startup(async () => {
               'Upload a video of yourself making a climb with at least 10 holds',
             netUpvotesRequired: 10,
             currentNetUpvotes: 0,
-            xpPoints: 30
+            xpPoints: 30,
+            children: ['3']
           },
-          position: { x: 300, y: 200 }
+          position: { x: 300, y: 100 }
         },
         {
-          id: 'turn',
+          id: '3',
           type: 'view-node-locked',
           data: {
             label: 'Turning Techniques',
@@ -387,14 +443,16 @@ Meteor.startup(async () => {
             requirements: 'Upload a video of yourself turning while climbing',
             netUpvotesRequired: 10,
             currentNetUpvotes: 0,
-            xpPoints: 75
+            xpPoints: 75,
+            children: []
           },
-          position: { x: 300, y: 300 }
+          position: { x: 300, y: 200 }
         }
       ],
       skillEdges: [
-        { id: 'e1', source: 'bouldering', target: 'climbing-techniques' },
-        { id: 'e2', source: 'climbing-techniques', target: 'turn' }
+        { id: 'e1', source: '0', target: '1' },
+        { id: 'e2', source: '0', target: '2' },
+        { id: 'e3', source: '2', target: '3' }
       ],
       admins: ['tennispro'],
       subscribers: ['playerZ', 'coachY']
@@ -412,19 +470,18 @@ Meteor.startup(async () => {
       tags: ['star wars', 'jedi', 'force', 'fiction'],
       skillNodes: [
         {
-          id: 'root',
+          id: '0',
           type: 'root',
           data: {
             label: 'Youngling Initiation 🌟',
             description: 'Begin your Jedi journey.',
-            progressXp: null,
             requirements: 'None',
             xpPoints: null
           },
           position: { x: 0, y: 0 }
         },
         {
-          id: 'force-sense',
+          id: '1',
           type: 'view-node-unlocked',
           data: {
             label: 'Force Sensitivity ✨',
@@ -433,12 +490,13 @@ Meteor.startup(async () => {
               'Watch a video about the Force and answer 3 quiz questions.',
             netUpvotesRequired: 10,
             currentNetUpvotes: 0,
-            xpPoints: 10
+            xpPoints: 10,
+            children: ['4']
           },
           position: { x: 150, y: 100 }
         },
         {
-          id: 'lightsaber-basics',
+          id: '2',
           type: 'view-node-unlocked',
           data: {
             label: 'Lightsaber Basics ⚔️',
@@ -446,12 +504,13 @@ Meteor.startup(async () => {
             requirements: 'Upload a video of you mimicking Form I (Shii-Cho).',
             netUpvotesRequired: 10,
             currentNetUpvotes: 0,
-            xpPoints: 15
+            xpPoints: 15,
+            children: ['5']
           },
           position: { x: -150, y: 100 }
         },
         {
-          id: 'meditation',
+          id: '3',
           type: 'view-node-unlocked',
           data: {
             label: 'Jedi Meditation 🧘‍♂️',
@@ -459,12 +518,13 @@ Meteor.startup(async () => {
             requirements: 'Record a 2-minute meditation log.',
             netUpvotesRequired: 10,
             currentNetUpvotes: 0,
-            xpPoints: 10
+            xpPoints: 10,
+            children: []
           },
           position: { x: 0, y: 200 }
         },
         {
-          id: 'telekinesis',
+          id: '4',
           type: 'view-node-locked',
           data: {
             label: 'Force Telekinesis 🌀',
@@ -473,12 +533,13 @@ Meteor.startup(async () => {
               'Upload a short creative video simulating telekinesis.',
             netUpvotesRequired: 10,
             currentNetUpvotes: 0,
-            xpPoints: 20
+            xpPoints: 20,
+            children: []
           },
           position: { x: 200, y: 300 }
         },
         {
-          id: 'duel',
+          id: '5',
           type: 'view-node-locked',
           data: {
             label: 'Lightsaber Duel 🥷',
@@ -487,17 +548,18 @@ Meteor.startup(async () => {
               'Upload a video of a lightsaber duel (with a friend or animation).',
             netUpvotesRequired: 10,
             currentNetUpvotes: 0,
-            xpPoints: 10
+            xpPoints: 10,
+            children: []
           },
           position: { x: -200, y: 300 }
         }
       ],
       skillEdges: [
-        { id: 'e1', source: 'root', target: 'force-sense' },
-        { id: 'e2', source: 'root', target: 'lightsaber-basics' },
-        { id: 'e3', source: 'root', target: 'meditation' },
-        { id: 'e4', source: 'force-sense', target: 'telekinesis' },
-        { id: 'e5', source: 'lightsaber-basics', target: 'duel' }
+        { id: 'e1', source: '0', target: '1' },
+        { id: 'e2', source: '0', target: '2' },
+        { id: 'e3', source: '0', target: '3' },
+        { id: 'e4', source: '1', target: '4' },
+        { id: 'e5', source: '2', target: '5' }
       ],
       admins: ['masterYoda'],
       subscribers: ['padawan1', 'padawan2']

--- a/imports/api/publications/SkillTree.js
+++ b/imports/api/publications/SkillTree.js
@@ -303,7 +303,7 @@ Meteor.startup(async () => {
       skillEdges: [
         { id: 'e1', source: '0', target: '1' },
         { id: 'e2', source: '0', target: '2' },
-        { id: 'e3', source: '0', target: '3' },
+        { id: 'e3', source: '0', target: '3' }
       ],
       admins: ['cricketpro'],
       subscribers: ['user1', 'user2']
@@ -401,7 +401,7 @@ Meteor.startup(async () => {
             description: 'root',
             requirements: 'root',
             xpPoints: null,
-            children: ['1','2']
+            children: ['1', '2']
           },
           position: { x: 0, y: 0 }
         },

--- a/imports/api/publications/Subscriptions.js
+++ b/imports/api/publications/Subscriptions.js
@@ -6,146 +6,146 @@ Meteor.publish('subscriptions', () => SubscriptionsCollection.find());
 Meteor.startup(async () => {
   await SubscriptionsCollection.removeAsync({});
 
-  const dummyProgressTree = [
-    {
-      userId: 123123,
-      skilltreeId: 'dummyskilltreeId',
-      totalXp: 10,
-      skillNodes: [
-        {
-          id: '0',
-          type: 'root',
-          data: {
-            label: 'root',
-            description: 'root',
-            requirements: 'root',
-            xpPoints: null
-          },
-          position: { x: 0, y: 0 }
-        },
-        {
-          id: '1',
-          type: 'view-node-unlocked',
-          data: {
-            label: 'basic dribbling 🏀',
-            description: 'Learn how to dribble the basketball effectively.',
-            netUpvotesRequired: 10,
-            currentNetUpvotes: 0,
-            xpPoints: 10,
-            requirements: 'Upload a video of yourself dribbling for 10 seconds',
-            proofId: 'testProof4'
-          },
-          position: { x: 200, y: 300 }
-        },
-        {
-          id: '2',
-          type: 'view-node-unlocked',
-          data: {
-            label: 'Layup 🏃‍♂️',
-            description:
-              ' A close-range shot taken by driving toward the basket and laying the ball off the backboard.',
-            requirements: 'Upload a video of yourself',
-            netUpvotesRequired: 10,
-            currentNetUpvotes: 0,
-            xpPoints: 10
-          },
-          position: { x: 200, y: 200 }
-        },
-        {
-          id: '3',
-          type: 'view-node-unlocked',
-          data: {
-            label: 'Spin Move 😵',
-            description: 'Learn how to do a spin move.',
-            requirements: 'Upload a video of yourself',
-            netUpvotesRequired: 15,
-            currentNetUpvotes: 0,
-            xpPoints: 15
-          },
-          position: { x: 200, y: 100 }
-        },
-        {
-          id: '4',
-          type: 'view-node-unlocked',
-          data: {
-            label: 'Agility 💨',
-            description: 'Learn how to be agile.',
-            requirements:
-              'Upload a video of yourself doing the illinois agility test',
-            netUpvotesRequired: 10,
-            currentNetUpvotes: 0,
-            xpPoints: 10
-          },
-          position: { x: 0, y: 100 }
-        },
-        {
-          id: '5',
-          type: 'view-node-unlocked',
-          data: {
-            label: 'Shooting Form 🎯',
-            description: 'Learn how to do proper shooting form.',
-            requirements: 'Upload a video of yourself',
-            netUpvotesRequired: 10,
-            currentNetUpvotes: 0,
-            xpPoints: 10
-          },
-          position: { x: -200, y: 300 }
-        },
-        {
-          id: '6',
-          type: 'view-node-unlocked',
-          data: {
-            label: 'Free Throws 💸',
-            description: 'Learn how to do free throws.',
-            requirements: 'Upload a video of yourself',
-            netUpvotesRequired: 10,
-            currentNetUpvotes: 0,
-            xpPoints: 10
-          },
-          position: { x: -150, y: 200 }
-        },
-        {
-          id: '7',
-          type: 'view-node-locked',
-          data: {
-            label: 'Three Pointers 💧',
-            description: 'Learn how to do a spin move.',
-            requirements: 'Upload a video of yourself',
-            netUpvotesRequired: 10,
-            currentNetUpvotes: 0,
-            xpPoints: 10
-          },
-          position: { x: -250, y: 100 }
-        },
-        {
-          id: '8',
-          type: 'view-node-unlocked',
-          data: {
-            label: 'Mid Range 🥶',
-            description: 'Learn how to do a spin move.',
-            requirements: 'Upload a video of yourself',
-            netUpvotesRequired: 10,
-            currentNetUpvotes: 0,
-            xpPoints: 10
-          },
-          position: { x: -350, y: 200 }
-        }
-      ],
-      skillEdges: [
-        { id: 'e1', source: '0', target: '7' },
-        { id: 'e2', source: '0', target: '4' },
-        { id: 'e3', source: '0', target: '3' },
-        { id: 'e4', source: '3', target: '2' },
-        { id: 'e5', source: '2', target: '1' },
-        { id: 'e6', source: '7', target: '6' },
-        { id: 'e7', source: '7', target: '8' },
-        { id: 'e8', source: '6', target: '5' },
-        { id: 'e9', source: '8', target: '5' }
-      ],
-      roles: ['user'],
-      active: true
-    }
-  ];
+  // const dummyProgressTree = [
+  //   {
+  //     userId: 123123,
+  //     skillTreeId: 'dummySkillTreeID',
+  //     totalXp: 10,
+  //     skillNodes: [
+  //       {
+  //         id: '0',
+  //         type: 'root',
+  //         data: {
+  //           label: 'root',
+  //           description: 'root',
+  //           requirements: 'root',
+  //           xpPoints: null
+  //         },
+  //         position: { x: 0, y: 0 }
+  //       },
+  //       {
+  //         id: '1',
+  //         type: 'view-node-unlocked',
+  //         data: {
+  //           label: 'basic dribbling 🏀',
+  //           description: 'Learn how to dribble the basketball effectively.',
+  //           netUpvotesRequired: 10,
+  //           currentNetUpvotes: 0,
+  //           xpPoints: 10,
+  //           requirements: 'Upload a video of yourself dribbling for 10 seconds',
+  //           proofId: 'testProof4'
+  //         },
+  //         position: { x: 200, y: 300 }
+  //       },
+  //       {
+  //         id: '2',
+  //         type: 'view-node-unlocked',
+  //         data: {
+  //           label: 'Layup 🏃‍♂️',
+  //           description:
+  //             ' A close-range shot taken by driving toward the basket and laying the ball off the backboard.',
+  //           requirements: 'Upload a video of yourself',
+  //           netUpvotesRequired: 10,
+  //           currentNetUpvotes: 0,
+  //           xpPoints: 10
+  //         },
+  //         position: { x: 200, y: 200 }
+  //       },
+  //       {
+  //         id: '3',
+  //         type: 'view-node-unlocked',
+  //         data: {
+  //           label: 'Spin Move 😵',
+  //           description: 'Learn how to do a spin move.',
+  //           requirements: 'Upload a video of yourself',
+  //           netUpvotesRequired: 15,
+  //           currentNetUpvotes: 0,
+  //           xpPoints: 15
+  //         },
+  //         position: { x: 200, y: 100 }
+  //       },
+  //       {
+  //         id: '4',
+  //         type: 'view-node-unlocked',
+  //         data: {
+  //           label: 'Agility 💨',
+  //           description: 'Learn how to be agile.',
+  //           requirements:
+  //             'Upload a video of yourself doing the illinois agility test',
+  //           netUpvotesRequired: 10,
+  //           currentNetUpvotes: 0,
+  //           xpPoints: 10
+  //         },
+  //         position: { x: 0, y: 100 }
+  //       },
+  //       {
+  //         id: '5',
+  //         type: 'view-node-unlocked',
+  //         data: {
+  //           label: 'Shooting Form 🎯',
+  //           description: 'Learn how to do proper shooting form.',
+  //           requirements: 'Upload a video of yourself',
+  //           netUpvotesRequired: 10,
+  //           currentNetUpvotes: 0,
+  //           xpPoints: 10
+  //         },
+  //         position: { x: -200, y: 300 }
+  //       },
+  //       {
+  //         id: '6',
+  //         type: 'view-node-unlocked',
+  //         data: {
+  //           label: 'Free Throws 💸',
+  //           description: 'Learn how to do free throws.',
+  //           requirements: 'Upload a video of yourself',
+  //           netUpvotesRequired: 10,
+  //           currentNetUpvotes: 0,
+  //           xpPoints: 10
+  //         },
+  //         position: { x: -150, y: 200 }
+  //       },
+  //       {
+  //         id: '7',
+  //         type: 'view-node-locked',
+  //         data: {
+  //           label: 'Three Pointers 💧',
+  //           description: 'Learn how to do a spin move.',
+  //           requirements: 'Upload a video of yourself',
+  //           netUpvotesRequired: 10,
+  //           currentNetUpvotes: 0,
+  //           xpPoints: 10
+  //         },
+  //         position: { x: -250, y: 100 }
+  //       },
+  //       {
+  //         id: '8',
+  //         type: 'view-node-unlocked',
+  //         data: {
+  //           label: 'Mid Range 🥶',
+  //           description: 'Learn how to do a spin move.',
+  //           requirements: 'Upload a video of yourself',
+  //           netUpvotesRequired: 10,
+  //           currentNetUpvotes: 0,
+  //           xpPoints: 10
+  //         },
+  //         position: { x: -350, y: 200 }
+  //       }
+  //     ],
+  //     skillEdges: [
+  //       { id: 'e1', source: '0', target: '7' },
+  //       { id: 'e2', source: '0', target: '4' },
+  //       { id: 'e3', source: '0', target: '3' },
+  //       { id: 'e4', source: '3', target: '2' },
+  //       { id: 'e5', source: '2', target: '1' },
+  //       { id: 'e6', source: '7', target: '6' },
+  //       { id: 'e7', source: '7', target: '8' },
+  //       { id: 'e8', source: '6', target: '5' },
+  //       { id: 'e9', source: '8', target: '5' }
+  //     ],
+  //     roles: ['user'],
+  //     active: true
+  //   }
+  // ];
 
   // // Insert dummy data
   // for (const progressTree of dummyProgressTree) {

--- a/imports/api/publications/Subscriptions.js
+++ b/imports/api/publications/Subscriptions.js
@@ -18,7 +18,6 @@ Meteor.startup(async () => {
           data: {
             label: 'root',
             description: 'root',
-            progressXp: null,
             requirements: 'root',
             xpPoints: null
           },
@@ -60,7 +59,7 @@ Meteor.startup(async () => {
             description: 'Learn how to do a spin move.',
             requirements: 'Upload a video of yourself',
             netUpvotesRequired: 15,
-            currentNetUpvotes: 3,
+            currentNetUpvotes: 0,
             xpPoints: 15
           },
           position: { x: 200, y: 100 }
@@ -148,8 +147,8 @@ Meteor.startup(async () => {
     }
   ];
 
-  // Insert dummy data
-  for (const progressTree of dummyProgressTree) {
-    await SubscriptionsCollection.insertAsync(progressTree);
-  }
+  // // Insert dummy data
+  // for (const progressTree of dummyProgressTree) {
+  //   await SubscriptionsCollection.insertAsync(progressTree);
+  // }
 });

--- a/imports/api/publications/Users.js
+++ b/imports/api/publications/Users.js
@@ -185,7 +185,6 @@ const dummyProgressTree = [
   }
 ];
 
-
 // [Mock Data] via Meteor Startup
 Meteor.startup(async () => {
   // Remove existing users to avoid duplicates (debug only)
@@ -290,11 +289,7 @@ Meteor.startup(async () => {
     }
   });
 
-  await Meteor.callAsync(
-    'skilltrees.subscribeUser',
-    'basketball',
-    sampleId
-  );
+  await Meteor.callAsync('skilltrees.subscribeUser', 'basketball', sampleId);
 
   await Meteor.callAsync(
     'skilltrees.subscribeUser',

--- a/imports/api/publications/Users.js
+++ b/imports/api/publications/Users.js
@@ -293,6 +293,12 @@ Meteor.startup(async () => {
   await Meteor.callAsync(
     'skilltrees.subscribeUser',
     'basketball',
+    sampleId
+  );
+
+  await Meteor.callAsync(
+    'skilltrees.subscribeUser',
+    'basketball',
     communityMemberA
   );
 

--- a/imports/api/publications/Users.js
+++ b/imports/api/publications/Users.js
@@ -47,9 +47,9 @@ const dummyProgressTree = [
         data: {
           label: 'root',
           description: 'root',
-          progressXp: null,
           requirements: 'root',
-          xpPoints: null
+          xpPoints: null,
+          children: ['7', '4', '3']
         },
         position: { x: 0, y: 0 }
       },
@@ -63,7 +63,8 @@ const dummyProgressTree = [
           currentNetUpvotes: 0,
           xpPoints: 10,
           requirements: 'Upload a video of yourself dribbling for 10 seconds',
-          proofId: 'testProofId'
+          proofId: 'testProofId',
+          children: []
         },
         position: { x: 200, y: 300 }
       },
@@ -73,11 +74,12 @@ const dummyProgressTree = [
         data: {
           label: 'Layup 🏃‍♂️',
           description:
-            ' A close-range shot taken by driving toward the basket and laying the ball off the backboard.',
+            'A close-range shot taken by driving toward the basket and laying the ball off the backboard.',
           requirements: 'Upload a video of yourself',
           netUpvotesRequired: 10,
           currentNetUpvotes: 0,
-          xpPoints: 10
+          xpPoints: 10,
+          children: ['1']
         },
         position: { x: 200, y: 200 }
       },
@@ -89,8 +91,9 @@ const dummyProgressTree = [
           description: 'Learn how to do a spin move.',
           requirements: 'Upload a video of yourself',
           netUpvotesRequired: 15,
-          currentNetUpvotes: 3,
-          xpPoints: 15
+          currentNetUpvotes: 0,
+          xpPoints: 15,
+          children: ['2']
         },
         position: { x: 200, y: 100 }
       },
@@ -104,7 +107,8 @@ const dummyProgressTree = [
             'Upload a video of yourself doing the illinois agility test',
           netUpvotesRequired: 10,
           currentNetUpvotes: 0,
-          xpPoints: 10
+          xpPoints: 10,
+          children: []
         },
         position: { x: 0, y: 100 }
       },
@@ -117,7 +121,8 @@ const dummyProgressTree = [
           requirements: 'Upload a video of yourself',
           netUpvotesRequired: 10,
           currentNetUpvotes: 0,
-          xpPoints: 10
+          xpPoints: 10,
+          children: []
         },
         position: { x: -200, y: 300 }
       },
@@ -130,7 +135,8 @@ const dummyProgressTree = [
           requirements: 'Upload a video of yourself',
           netUpvotesRequired: 10,
           currentNetUpvotes: 0,
-          xpPoints: 10
+          xpPoints: 10,
+          children: ['5']
         },
         position: { x: -150, y: 200 }
       },
@@ -143,7 +149,8 @@ const dummyProgressTree = [
           requirements: 'Upload a video of yourself',
           netUpvotesRequired: 10,
           currentNetUpvotes: 0,
-          xpPoints: 10
+          xpPoints: 10,
+          children: ['6', '8']
         },
         position: { x: -250, y: 100 }
       },
@@ -156,7 +163,8 @@ const dummyProgressTree = [
           requirements: 'Upload a video of yourself',
           netUpvotesRequired: 10,
           currentNetUpvotes: 0,
-          xpPoints: 10
+          xpPoints: 10,
+          children: ['5']
         },
         position: { x: -350, y: 200 }
       }
@@ -176,6 +184,7 @@ const dummyProgressTree = [
     active: true
   }
 ];
+
 
 // [Mock Data] via Meteor Startup
 Meteor.startup(async () => {

--- a/imports/api/schemas/SkillTree.js
+++ b/imports/api/schemas/SkillTree.js
@@ -28,6 +28,14 @@ const skillDataSchema = new SimpleSchema({
     optional: true,
     defaultValue: 0
   },
+  children: {
+    type: Array,
+    label: 'List of child nodes',
+    optional: true,
+    defaultValue: []
+  },
+  'children.$': String,
+
   xpPoints: {
     type: Number,
     label: 'XP Points earned for completing this skill',

--- a/imports/api/schemas/Subscriptions.js
+++ b/imports/api/schemas/Subscriptions.js
@@ -16,12 +16,6 @@ const skillDataSchema = new SimpleSchema({
     min: 1,
     optional: true
   },
-  progressXp: {
-    type: Number,
-    label: 'Progress XP',
-    optional: true,
-    defaultValue: 0
-  },
   netUpvotesRequired: {
     type: Number,
     label: 'Net Upvotes Required to complete this skill',

--- a/imports/ui/components/SkillTrees/Nodes/ViewNode.jsx
+++ b/imports/ui/components/SkillTrees/Nodes/ViewNode.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 export function ViewNode({ data, isUnlocked }) {
   const progress = isUnlocked
-    ? Math.floor((data.progressXp / data.xpPoints) * 100)
+    ? Math.floor((data.currentNetUpvotes / data.netUpvotesRequired) * 100)
     : 0;
 
   const displayColour = isUnlocked ? '#328E6E' : '#8C8C8C';
@@ -34,16 +34,26 @@ export function ViewNode({ data, isUnlocked }) {
           {data.label || 'Untitled'}
         </strong>
         <br />
-        {isUnlocked && (
-          <div className="w-full bg-gray-200 rounded-full dark:bg-gray-700">
-            <div
-              className="bg-[#FBBC05] text-xs font-medium text-blue-100 text-center p-0.5 leading-none rounded-full"
-              style={{ width: `${progress}%` }}
-            >
-              {`${data.progressXp || 0} / ${data.xpPoints}`}
-            </div>
+        {isUnlocked ? (
+          <div className="w-full bg-gray-200 dark:bg-gray-700 relative">
+            {progress > 0 && (
+              <div
+                className="bg-[#FBBC05] absolute left-0 top-0 bottom-0 rounded-half"
+                style={{ width: `${progress}%` }}
+              />
+            )}
+            <span className="relative text-xs text-white block text-center p-0.5">
+              {`${data.currentNetUpvotes || 0} / ${data.netUpvotesRequired}`}
+            </span>
           </div>
-        )}
+        ) :
+          (
+            <div className="text-gray-300 text-xs text-center">
+              Locked
+            </div>
+          )
+        }
+
       </div>
       <Handle
         type="source"

--- a/imports/ui/components/SkillTrees/Nodes/ViewNode.jsx
+++ b/imports/ui/components/SkillTrees/Nodes/ViewNode.jsx
@@ -46,14 +46,9 @@ export function ViewNode({ data, isUnlocked }) {
               {`${data.currentNetUpvotes || 0} / ${data.netUpvotesRequired}`}
             </span>
           </div>
-        ) :
-          (
-            <div className="text-gray-300 text-xs text-center">
-              Locked
-            </div>
-          )
-        }
-
+        ) : (
+          <div className="text-gray-300 text-xs text-center">Locked</div>
+        )}
       </div>
       <Handle
         type="source"

--- a/imports/ui/components/SkillTrees/SkillTree.jsx
+++ b/imports/ui/components/SkillTrees/SkillTree.jsx
@@ -17,7 +17,6 @@ import { ViewNode } from './Nodes/ViewNode';
 import { SkillEditForm } from './Skill/SkillEditForm';
 import { SkillViewForm } from './Skill/SkillViewForm';
 import { Button } from 'flowbite-react';
-// This is the logic and page for creating/editing a skilltree
 
 const createNewEmptyNode = isEmpty => props => (
   <NewEmptyNode {...props} isEmpty={isEmpty} />
@@ -43,6 +42,9 @@ export const SkillTreeLogic = ({
   savedEdges,
   onBack
 }) => {
+  const [viewMode, setViewMode] = useState('edit'); // 'edit' or 'view'
+  const [workingNodes, setWorkingNodes] = useState(null); // Store nodes for preview
+
   // Reattach OpenEditor handlers to nodes. They are lost when saved to DB
   const attachOpenEditorHandlers = (savedNodes = []) =>
     savedNodes.map(node => ({
@@ -55,11 +57,12 @@ export const SkillTreeLogic = ({
     }));
 
   var initialNodes = attachOpenEditorHandlers(savedNodes) ?? [];
-  //For creating a fresh new tree
-  console.log('Check if admin');
-  console.log(isAdmin);
-  if (isAdmin) {
-    console.log('I am admin');
+  
+  // Determine effective mode: admins can switch between edit and view
+  const effectiveMode = isAdmin && viewMode === 'view' ? 'view' : (isAdmin ? 'edit' : 'view');
+  
+  if (effectiveMode === 'edit') {
+    console.log('Edit mode');
     if (!savedNodes) {
       initialNodes = [
         {
@@ -78,9 +81,7 @@ export const SkillTreeLogic = ({
       }));
     }
   } else {
-    // console.log('saved nodes:', initialNodes); // Use console.log with comma to see the actual objects
-    // console.log('saved node root:', initialNodes[0]);
-    console.log('Non admin path taken');
+    console.log('View mode - determining locked/unlocked nodes');
     //check each parent
     for (let i = 0; i < initialNodes.length; i++) {
       // Ensure children exists and is an array
@@ -91,10 +92,10 @@ export const SkillTreeLogic = ({
 
         //check each child by ID
         for (let j = 0; j < children.length; j++) {
-          const childNode = initialNodes[Number(children[j])];
+          const childNode = initialNodes.find(n => n.id === children[j]);
 
           // Check if child node exists and is verified
-          if (!childNode.data.verified) {
+          if (!childNode || !childNode.data.verified) {
             unlock = false;
             break;
           }
@@ -110,7 +111,10 @@ export const SkillTreeLogic = ({
         initialNodes[i].type = 'view-node-unlocked';
       }
     }
-    initialNodes[0].type = 'root';
+    // Only set root type if there are nodes
+    if (initialNodes.length > 0) {
+      initialNodes[0].type = 'root';
+    }
   }
 
   const initialEdges = savedEdges ?? [];
@@ -129,6 +133,61 @@ export const SkillTreeLogic = ({
   useEffect(() => {
     nodesRef.current = nodes;
   }, [nodes]);
+
+  // Update node types when view mode changes
+  useEffect(() => {
+    if (!isAdmin) return; // Only applies to admins
+    
+    if (viewMode === 'view') {
+      // Save current working nodes before switching to view mode
+      setWorkingNodes(nodes);
+      
+      // Switch to user view: update node types to locked/unlocked
+      const updatedNodes = nodes.map((node, index) => {
+        if (node.id === '0') {
+          return { ...node, type: 'root', draggable: false };
+        }
+        
+        const children = node.data.children || [];
+        let unlocked = true;
+        
+        if (children.length > 0) {
+          for (const childId of children) {
+            const childNode = nodes.find(n => n.id === childId);
+            if (!childNode?.data?.verified) {
+              unlocked = false;
+              break;
+            }
+          }
+        }
+        
+        return {
+          ...node,
+          type: unlocked ? 'view-node-unlocked' : 'view-node-locked',
+          draggable: false
+        };
+      });
+      setNodes(updatedNodes);
+    } else {
+      // Switch to edit mode: restore working nodes if they exist
+      if (workingNodes) {
+        const updatedNodes = workingNodes.map(node => ({
+          ...node,
+          type: node.id === '0' ? 'root' : 'new-populated',
+          draggable: true
+        }));
+        setNodes(updatedNodes);
+      } else {
+        // If no working nodes saved, just update types
+        const updatedNodes = nodes.map(node => ({
+          ...node,
+          type: node.id === '0' ? 'root' : 'new-populated',
+          draggable: true
+        }));
+        setNodes(updatedNodes);
+      }
+    }
+  }, [viewMode]);
 
   const handleNodeEdit = useCallback(
     (nodeId, updatedData) => {
@@ -236,6 +295,7 @@ export const SkillTreeLogic = ({
     },
     [screenToFlowPosition, handleOpenEditor, setNodes, setEdges]
   );
+
   const onEdgesDelete = useCallback(
     deletedEdges => {
       deletedEdges.forEach(deletedEdge => {
@@ -259,6 +319,7 @@ export const SkillTreeLogic = ({
     },
     [setNodes]
   );
+
   const handleOnSave = () => {
     onSave({ nodes, edges });
   };
@@ -274,27 +335,45 @@ export const SkillTreeLogic = ({
     Meteor.callAsync('saveSubscription', id, updatedNodes, edges);
   };
 
-  // const printNodes = () => {
-  //   console.log('Printer triggered');
-  //   console.log(nodes);
-  // };
-
   return (
     <>
       {isAdmin && (
         <>
-          <h2 className="text-4xl font-bold" style={{ color: '#328E6E' }}>
-            Add Skills
-          </h2>
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-4xl font-bold" style={{ color: '#328E6E' }}>
+              {viewMode === 'edit' ? 'Add Skills' : 'Preview User View'}
+            </h2>
+            
+            <div className="flex gap-2">
+              <Button
+                pill
+                color={viewMode === 'edit' ? 'green' : 'gray'}
+                className="focus:ring-0 w-32 font-bold text-md enabled:cursor-pointer"
+                onClick={() => setViewMode('edit')}
+              >
+                Edit Mode
+              </Button>
+              <Button
+                pill
+                color={viewMode === 'view' ? 'green' : 'gray'}
+                className="focus:ring-0 w-32 font-bold text-md enabled:cursor-pointer"
+                onClick={() => setViewMode('view')}
+              >
+                User View
+              </Button>
+            </div>
+          </div>
 
-          <Button
-            pill
-            color="green"
-            className="focus:ring-0 w-32 font-bold text-md enabled:cursor-pointer"
-            onClick={handleOnSave}
-          >
-            Save
-          </Button>
+          {viewMode === 'edit' && (
+            <Button
+              pill
+              color="green"
+              className="focus:ring-0 w-32 font-bold text-md enabled:cursor-pointer mb-2"
+              onClick={handleOnSave}
+            >
+              Save
+            </Button>
+          )}
         </>
       )}
 
@@ -304,10 +383,10 @@ export const SkillTreeLogic = ({
           nodeTypes={nodeTypes}
           onNodesChange={onNodesChange}
           edges={edges}
-          onEdgesChange={isAdmin ? onEdgesChange : null}
-          onConnect={isAdmin ? onConnect : null}
-          onConnectEnd={isAdmin ? onConnectEnd : null}
-          onEdgesDelete={isAdmin ? onEdgesDelete : null}
+          onEdgesChange={effectiveMode === 'edit' ? onEdgesChange : null}
+          onConnect={effectiveMode === 'edit' ? onConnect : null}
+          onConnectEnd={effectiveMode === 'edit' ? onConnectEnd : null}
+          onEdgesDelete={effectiveMode === 'edit' ? onEdgesDelete : null}
           fitView
           nodeOrigin={nodeOrigin}
         >
@@ -316,7 +395,8 @@ export const SkillTreeLogic = ({
           <Controls />
         </ReactFlow>
       </div>
-      {isAdmin && (
+
+      {isAdmin && viewMode === 'edit' && (
         <Button
           pill
           color="green"
@@ -328,9 +408,10 @@ export const SkillTreeLogic = ({
           Back
         </Button>
       )}
+
       {/* Modal rendered outside ReactFlow */}
       {editingNode &&
-        (isAdmin ? (
+        (effectiveMode === 'edit' ? (
           <SkillEditForm
             editingNode={editingNode}
             onSave={updatedData => {
@@ -352,6 +433,7 @@ export const SkillTreeLogic = ({
 };
 
 export const SkillTreeEdit = ({
+  id,
   isAdmin,
   onSave,
   savedNodes,
@@ -360,6 +442,7 @@ export const SkillTreeEdit = ({
 }) => (
   <ReactFlowProvider>
     <SkillTreeLogic
+      id={id}
       isAdmin={isAdmin}
       onSave={onSave}
       savedNodes={savedNodes}

--- a/imports/ui/components/SkillTrees/SkillTree.jsx
+++ b/imports/ui/components/SkillTrees/SkillTree.jsx
@@ -108,7 +108,7 @@ export const SkillTreeLogic = ({
 
   const initialEdges = savedEdges ?? [];
 
-  const idRef = useRef(1);
+  const idRef = useRef(initialNodes.length);
   const getId = () => `${idRef.current++}`;
   const nodeOrigin = [0.5, 0];
 

--- a/imports/ui/components/SkillTrees/SkillTree.jsx
+++ b/imports/ui/components/SkillTrees/SkillTree.jsx
@@ -57,10 +57,10 @@ export const SkillTreeLogic = ({
     }));
 
   var initialNodes = attachOpenEditorHandlers(savedNodes) ?? [];
-  
+
   // Determine effective mode: admins can switch between edit and view
   const effectiveMode = isAdmin && viewMode === 'view' ? 'view' : (isAdmin ? 'edit' : 'view');
-  
+
   if (effectiveMode === 'edit') {
     console.log('Edit mode');
     if (!savedNodes) {
@@ -137,20 +137,20 @@ export const SkillTreeLogic = ({
   // Update node types when view mode changes
   useEffect(() => {
     if (!isAdmin) return; // Only applies to admins
-    
+
     if (viewMode === 'view') {
       // Save current working nodes before switching to view mode
       setWorkingNodes(nodes);
-      
+
       // Switch to user view: update node types to locked/unlocked
       const updatedNodes = nodes.map((node, index) => {
         if (node.id === '0') {
           return { ...node, type: 'root', draggable: false };
         }
-        
+
         const children = node.data.children || [];
         let unlocked = true;
-        
+
         if (children.length > 0) {
           for (const childId of children) {
             const childNode = nodes.find(n => n.id === childId);
@@ -160,7 +160,7 @@ export const SkillTreeLogic = ({
             }
           }
         }
-        
+
         return {
           ...node,
           type: unlocked ? 'view-node-unlocked' : 'view-node-locked',
@@ -260,7 +260,8 @@ export const SkillTreeLogic = ({
             children: [],
             verified: false,
             xpPoints: 0,
-            progressXp: 0,
+            netUpvotesRequired: 10,
+            currentNetUpvotes: 0,
             onOpenEditor: () => handleOpenEditor(id)
           },
           origin: nodeOrigin
@@ -343,7 +344,7 @@ export const SkillTreeLogic = ({
             <h2 className="text-4xl font-bold" style={{ color: '#328E6E' }}>
               {viewMode === 'edit' ? 'Add Skills' : 'Preview User View'}
             </h2>
-            
+
             <div className="flex gap-2">
               <Button
                 pill

--- a/imports/ui/components/SkillTrees/SkillTree.jsx
+++ b/imports/ui/components/SkillTrees/SkillTree.jsx
@@ -59,7 +59,8 @@ export const SkillTreeLogic = ({
   var initialNodes = attachOpenEditorHandlers(savedNodes) ?? [];
 
   // Determine effective mode: admins can switch between edit and view
-  const effectiveMode = isAdmin && viewMode === 'view' ? 'view' : (isAdmin ? 'edit' : 'view');
+  const effectiveMode =
+    isAdmin && viewMode === 'view' ? 'view' : isAdmin ? 'edit' : 'view';
 
   if (effectiveMode === 'edit') {
     console.log('Edit mode');
@@ -72,9 +73,8 @@ export const SkillTreeLogic = ({
           position: { x: 0, y: 0 }
         }
       ];
-    }
-    else {
-      console.log("setting type to edit");
+    } else {
+      console.log('setting type to edit');
       initialNodes = initialNodes.map(node => ({
         ...node,
         type: node.id === '0' ? 'root' : 'new-populated'

--- a/imports/ui/components/SkillTrees/SkillTree.jsx
+++ b/imports/ui/components/SkillTrees/SkillTree.jsx
@@ -70,6 +70,13 @@ export const SkillTreeLogic = ({
         }
       ];
     }
+    else {
+      console.log("setting type to edit");
+      initialNodes = initialNodes.map(node => ({
+        ...node,
+        type: node.id === '0' ? 'root' : 'new-populated'
+      }));
+    }
   } else {
     // console.log('saved nodes:', initialNodes); // Use console.log with comma to see the actual objects
     // console.log('saved node root:', initialNodes[0]);

--- a/imports/ui/components/SkillTrees/SkillTree.jsx
+++ b/imports/ui/components/SkillTrees/SkillTree.jsx
@@ -56,7 +56,10 @@ export const SkillTreeLogic = ({
 
   var initialNodes = attachOpenEditorHandlers(savedNodes) ?? [];
   //For creating a fresh new tree
+  console.log('Check if admin');
+  console.log(isAdmin);
   if (isAdmin) {
+    console.log('I am admin');
     if (!savedNodes) {
       initialNodes = [
         {
@@ -67,13 +70,10 @@ export const SkillTreeLogic = ({
         }
       ];
     }
-  }
-  //load user tree + check for parents
-  //load user tree + check for parents
-  else {
-    console.log('saved nodes:', initialNodes); // Use console.log with comma to see the actual objects
-    console.log('saved node root:', initialNodes[0]);
-
+  } else {
+    // console.log('saved nodes:', initialNodes); // Use console.log with comma to see the actual objects
+    // console.log('saved node root:', initialNodes[0]);
+    console.log('Non admin path taken');
     //check each parent
     for (let i = 0; i < initialNodes.length; i++) {
       // Ensure children exists and is an array
@@ -84,7 +84,7 @@ export const SkillTreeLogic = ({
 
         //check each child by ID
         for (let j = 0; j < children.length; j++) {
-          const childNode = children[j];
+          const childNode = initialNodes[Number(children[j])];
 
           // Check if child node exists and is verified
           if (!childNode.data.verified) {

--- a/imports/ui/components/SkillTrees/SkillTreeCommunityView.jsx
+++ b/imports/ui/components/SkillTrees/SkillTreeCommunityView.jsx
@@ -94,7 +94,7 @@ export const SkillTreeCommunityView = () => {
           <p>Terms & Conditions: {skilltree.termsAndConditions}</p>
         </div>
       </div>
-      <SkillTreeView id={id} isAdmin={false} />
+      <SkillTreeView id={id} />
       <Outlet />
     </div>
   );

--- a/imports/ui/components/SkillTrees/SkillTreeView.jsx
+++ b/imports/ui/components/SkillTrees/SkillTreeView.jsx
@@ -158,9 +158,12 @@ export const SkillTreeView = ({ id, onBack }) => {
       }));
       // await Meteor.callAsync('updateCreatedCommunities', skillTreeId);
       // await Meteor.callAsync('updateSubscribedCommunities', skillTreeId);
-      await Meteor.callAsync('saveSubscription', id,
+      await Meteor.callAsync(
+        'saveSubscription',
+        id,
         skilltreeToSave.skillNodes,
-        skilltreeToSave.skillEdges);
+        skilltreeToSave.skillEdges
+      );
       console.log('SkillTree updated successfully');
       toast.success('SkillTree updated!');
     } catch (error) {

--- a/imports/ui/components/SkillTrees/SkillTreeView.jsx
+++ b/imports/ui/components/SkillTrees/SkillTreeView.jsx
@@ -1,15 +1,17 @@
 import { ReactFlowProvider } from '@xyflow/react';
 import { useSubscribe, useFind } from 'meteor/react-meteor-data';
 import React, { useEffect, useState } from 'react';
-import { SkillTreeLogic } from './SkillTree';
+import { SkillTreeEdit } from './SkillTree';
 import { SkillTreeCollection } from '/imports/api/collections/SkillTree';
 import { SubscriptionsCollection } from '/imports/api/collections/Subscriptions';
 import { Meteor } from 'meteor/meteor';
+import { ToastContainer, toast, Flip } from 'react-toastify';
 
-export const SkillTreeView = ({ id, isAdmin, onBack }) => {
+export const SkillTreeView = ({ id, onBack }) => {
   // 1. Subscribe to the necessary data publications
   const isSkillTreesLoading = useSubscribe('skilltrees');
   const isSubscriptionsLoading = useSubscribe('subscriptions');
+  const [adminStatus, setAdminStatus] = useState(false);
 
   const userId = Meteor.userId();
 
@@ -24,7 +26,7 @@ export const SkillTreeView = ({ id, isAdmin, onBack }) => {
     [userId, id]
   )[0];
 
-  const [skilltree, setSkilltree] = useState(null);
+  const [skillTree, setSkillTree] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
 
   // 3. Determine which data to display (user's progress or the base tree)
@@ -33,10 +35,15 @@ export const SkillTreeView = ({ id, isAdmin, onBack }) => {
     if (!isSkillTreesLoading() && !isSubscriptionsLoading()) {
       if (userSubscription) {
         // If the user is subscribed, use their subscription data (which includes progress)
-        setSkilltree(userSubscription);
+        setSkillTree(userSubscription);
+        console.log('found subscription');
+        console.log(userSubscription);
+        if (userSubscription.roles.includes('admin')) {
+          setAdminStatus(true);
+        }
       } else {
         // Otherwise, fall back to the generic skill tree data
-        setSkilltree(baseSkillTree);
+        setSkillTree(baseSkillTree);
       }
     }
   }, [
@@ -50,13 +57,13 @@ export const SkillTreeView = ({ id, isAdmin, onBack }) => {
   useEffect(() => {
     const syncNodeUpvotes = async () => {
       // We only need to sync if the user is subscribed and has progress to update
-      if (!skilltree || !userSubscription) {
+      if (!skillTree || !userSubscription) {
         setIsLoading(false); // Stop loading if there's nothing to sync
         return;
       }
 
-      let updatedNodes = [...skilltree.skillNodes];
-      let updatedTotalXp = skilltree.totalXp || 0;
+      let updatedNodes = [...skillTree.skillNodes];
+      let updatedTotalXp = skillTree.totalXp || 0;
       let requireSyncing = false;
 
       await Promise.all(
@@ -91,10 +98,10 @@ export const SkillTreeView = ({ id, isAdmin, onBack }) => {
           'saveSubscription',
           id,
           updatedNodes,
-          skilltree.skillEdges,
+          skillTree.skillEdges,
           updatedTotalXp
         );
-        setSkilltree(prev => ({
+        setSkillTree(prev => ({
           ...prev,
           skillNodes: updatedNodes,
           totalXp: updatedTotalXp
@@ -103,31 +110,87 @@ export const SkillTreeView = ({ id, isAdmin, onBack }) => {
       setIsLoading(false); // End loading after sync is complete
     };
 
-    if (skilltree) {
+    if (skillTree) {
       syncNodeUpvotes();
     } else if (!isSkillTreesLoading() && !isSubscriptionsLoading()) {
       // If there's no data at all and we're done loading, stop the loading spinner
       setIsLoading(false);
     }
-  }, [skilltree]); // This effect runs when the skilltree data is first loaded
+  }, [skillTree]); // This effect runs when the skilltree data is first loaded
 
   if (isLoading) {
     return <div>Loading...</div>;
   }
 
-  if (!skilltree) {
+  if (!skillTree) {
     return <div>Skill Tree not found.</div>;
   }
 
+  const updateNodesAndEdges = ({ nodes, edges }) => {
+    console.log(
+      'updateNodesAndEdges called with nodes:',
+      nodes,
+      'and edges:',
+      edges
+    );
+    const updatedSkillTree = {
+      ...skillTree,
+      skillNodes: nodes,
+      skillEdges: edges
+    };
+    setSkillTree(updatedSkillTree);
+
+    console.log('skillTreeBeforeInsert', updatedSkillTree);
+    handleSaveSkillTree(updatedSkillTree);
+  };
+
+  const handleSaveSkillTree = async skilltreeToSave => {
+    try {
+      const updateData = { ...skilltreeToSave };
+      console.log('Updating existing tree with data:', updateData);
+
+      await Meteor.callAsync('skilltrees.update', id, updateData);
+
+      // Update local state
+      setSkillTree(prev => ({
+        ...prev,
+        ...updateData,
+        updatedAt: new Date()
+      }));
+      // await Meteor.callAsync('updateCreatedCommunities', skillTreeId);
+      // await Meteor.callAsync('updateSubscribedCommunities', skillTreeId);
+      await Meteor.callAsync('saveSubscription', id);
+      console.log('SkillTree updated successfully');
+      toast.success('SkillTree updated!');
+    } catch (error) {
+      console.error('Error saving skill tree:', error);
+      toast.error('Error saving SkillTree!');
+    }
+  };
+
   return (
     <ReactFlowProvider>
-      <SkillTreeLogic
+      <>{console.log(`adminStatus: ${adminStatus}`)}</>
+      <SkillTreeEdit
         id={id}
-        isAdmin={isAdmin}
-        onSave={() => {}}
-        savedNodes={skilltree.skillNodes}
-        savedEdges={skilltree.skillEdges}
+        isAdmin={adminStatus}
+        onSave={adminStatus ? updateNodesAndEdges : undefined}
+        savedNodes={skillTree.skillNodes}
+        savedEdges={skillTree.skillEdges}
         onBack={onBack}
+      />
+      <ToastContainer
+        position="top-right"
+        autoClose={3000}
+        hideProgressBar={false}
+        newestOnTop={false}
+        closeOnClick
+        rtl={false}
+        pauseOnFocusLoss
+        draggable
+        pauseOnHover
+        theme="light"
+        transition={Flip}
       />
     </ReactFlowProvider>
   );

--- a/imports/ui/components/SkillTrees/SkillTreeView.jsx
+++ b/imports/ui/components/SkillTrees/SkillTreeView.jsx
@@ -159,7 +159,9 @@ export const SkillTreeView = ({ id, onBack }) => {
       }));
       // await Meteor.callAsync('updateCreatedCommunities', skillTreeId);
       // await Meteor.callAsync('updateSubscribedCommunities', skillTreeId);
-      await Meteor.callAsync('saveSubscription', id);
+      await Meteor.callAsync('saveSubscription', id,
+        skilltreeToSave.skillNodes,
+        skilltreeToSave.skillEdges);
       console.log('SkillTree updated successfully');
       toast.success('SkillTree updated!');
     } catch (error) {

--- a/imports/ui/components/SkillTrees/SkillTreeView.jsx
+++ b/imports/ui/components/SkillTrees/SkillTreeView.jsx
@@ -83,7 +83,6 @@ export const SkillTreeView = ({ id, onBack }) => {
                 };
                 if (netUpvotes >= node.data.netUpvotesRequired) {
                   updatedNodeData.verified = true;
-                  updatedNodeData.progressXp = node.data.xpPoints;
                   updatedTotalXp += node.data.xpPoints;
                 }
                 updatedNodes[index] = { ...node, data: updatedNodeData };

--- a/imports/ui/pages/CreateSkillTree.jsx
+++ b/imports/ui/pages/CreateSkillTree.jsx
@@ -130,9 +130,12 @@ export const CreateSkillTree = () => {
         }));
         // await Meteor.callAsync('updateCreatedCommunities', skillTreeId);
         // await Meteor.callAsync('updateSubscribedCommunities', skillTreeId);
-        await Meteor.callAsync('saveSubscription', skillTreeId,
+        await Meteor.callAsync(
+          'saveSubscription',
+          skillTreeId,
           skilltreeToSave.skillNodes,
-          skilltreeToSave.skillEdges);
+          skilltreeToSave.skillEdges
+        );
         console.log('SkillTree updated successfully');
         toast.success('SkillTree updated!');
       }

--- a/imports/ui/pages/CreateSkillTree.jsx
+++ b/imports/ui/pages/CreateSkillTree.jsx
@@ -130,7 +130,9 @@ export const CreateSkillTree = () => {
         }));
         // await Meteor.callAsync('updateCreatedCommunities', skillTreeId);
         // await Meteor.callAsync('updateSubscribedCommunities', skillTreeId);
-        await Meteor.callAsync('saveSubscription', skillTreeId);
+        await Meteor.callAsync('saveSubscription', skillTreeId,
+          skilltreeToSave.skillNodes,
+          skilltreeToSave.skillEdges);
         console.log('SkillTree updated successfully');
         toast.success('SkillTree updated!');
       }

--- a/imports/ui/pages/CreateSkillTree.jsx
+++ b/imports/ui/pages/CreateSkillTree.jsx
@@ -9,12 +9,13 @@ import { AuthContext } from '/imports/utils/contexts/AuthContext';
 import { CreateTreeForm } from '../components/SkillTrees/CreateTreeForm';
 import { SkillTreeEdit } from '../components/SkillTrees/SkillTree';
 import { ToastContainer, toast, Flip } from 'react-toastify';
-import { useNavigate } from 'react-router-dom';
+import { update } from 'lodash';
+//import { useNavigate } from 'react-router-dom';
 
 export const CreateSkillTree = () => {
   //Current user id logged in
   const userId = useContext(AuthContext); // Reactive when value changes
-  const navigate = useNavigate();
+  //const navigate = useNavigate();
   const [showAddDetailsForm, setShowAddDetailsForm] = useState(true);
   const [showAddSkillsForm, setShowAddSkillsForm] = useState(false);
   const [skillTree, setSkillTree] = useState({
@@ -89,11 +90,17 @@ export const CreateSkillTree = () => {
 
   const handleSaveSkillTree = async skilltreeToSave => {
     try {
-      //Insert the new skilltree into the collection
-      const skilltreeId = await Meteor.callAsync(
-        'skilltrees.insert',
-        skilltreeToSave
-      );
+      let skilltreeId = skillTree._id;
+
+      if (!skilltreeId) {
+        // First save: insert new SkillTree
+        const newSkillTreeId = await Meteor.callAsync(
+          'skilltrees.insert',
+          skilltreeToSave
+        );
+        // Store the new ID
+        setSkillTree(prev => ({ ...prev, _id: newSkillTreeId })); 
+        skilltreeId = newSkillTreeId;
 
       //Update the owner's created communities list
       await Meteor.callAsync('updateCreatedCommunities', skilltreeId);
@@ -117,11 +124,24 @@ export const CreateSkillTree = () => {
       navigate('/dashboard', { state: { showSkillTreeCreatedToast: true } });
 
       console.log('Skill Tree saved successfully');
+      toast.success('Successfully created SkillTree!');
+      } else {
+        // Subsequent saves: update existing SkillTree
+        const { _id, ...updateData } = skilltreeToSave; // Exclude _id from update data
+        await Meteor.callAsync('skilltrees.update', skillTreeId, updateData);
+
+        setSkillTree(prev => ({
+          ...prev,
+          ...updateData,
+          updatedAt: new Date()
+        }));
+
+        toast.success('SkillTree updated!');
+      }
     } catch (error) {
       console.error('Error saving skill tree:', error);
+      toast.error('Error saving SkillTree!');
     }
-    // Show confirmation popup
-    toast.success('Successfully created SkillTree!');
   };
 
   return (

--- a/imports/ui/pages/CreateSkillTree.jsx
+++ b/imports/ui/pages/CreateSkillTree.jsx
@@ -9,11 +9,12 @@ import { AuthContext } from '/imports/utils/contexts/AuthContext';
 import { CreateTreeForm } from '../components/SkillTrees/CreateTreeForm';
 import { SkillTreeEdit } from '../components/SkillTrees/SkillTree';
 import { ToastContainer, toast, Flip } from 'react-toastify';
+import { useNavigate } from 'react-router-dom';
 
 export const CreateSkillTree = () => {
   //Current user id logged in
   const userId = useContext(AuthContext); // Reactive when value changes
-
+  const navigate = useNavigate();
   const [showAddDetailsForm, setShowAddDetailsForm] = useState(true);
   const [showAddSkillsForm, setShowAddSkillsForm] = useState(false);
   const [skillTree, setSkillTree] = useState({
@@ -103,6 +104,7 @@ export const CreateSkillTree = () => {
       //Add admin role to skilltree progression
       const updateOperation = {
         $addToSet: { roles: 'admin' }
+
       };
 
       await Meteor.callAsync(
@@ -111,6 +113,8 @@ export const CreateSkillTree = () => {
         userId,
         updateOperation
       );
+
+      navigate('/dashboard', { state: { showSkillTreeCreatedToast: true } });
 
       console.log('Skill Tree saved successfully');
     } catch (error) {

--- a/imports/ui/pages/CreateSkillTree.jsx
+++ b/imports/ui/pages/CreateSkillTree.jsx
@@ -9,7 +9,7 @@ import { AuthContext } from '/imports/utils/contexts/AuthContext';
 import { CreateTreeForm } from '../components/SkillTrees/CreateTreeForm';
 import { SkillTreeEdit } from '../components/SkillTrees/SkillTree';
 import { ToastContainer, toast, Flip } from 'react-toastify';
-import { update } from 'lodash';
+// import { update } from 'lodash';
 //import { useNavigate } from 'react-router-dom';
 
 export const CreateSkillTree = () => {
@@ -89,56 +89,56 @@ export const CreateSkillTree = () => {
   };
 
   const handleSaveSkillTree = async skilltreeToSave => {
-  // console.log("save clicked");
-  // console.log("Data to save:", skilltreeToSave);
-  
-  try {
-    let skillTreeId = skillTree._id;
+    try {
+      let skillTreeId = skillTree._id;
 
-    if (!skillTreeId) {
-      // First save: insert new SkillTree
-      const newSkillTreeId = await Meteor.callAsync(
-        'skilltrees.insert',
-        skilltreeToSave
-      );
-      // Store the new ID
-      setSkillTree(prev => ({ ...prev, _id: newSkillTreeId }));
-      skillTreeId = newSkillTreeId;
+      if (!skillTreeId) {
+        // First save: insert new SkillTree
+        const newSkillTreeId = await Meteor.callAsync(
+          'skilltrees.insert',
+          skilltreeToSave
+        );
+        // Store the new ID
+        setSkillTree(prev => ({ ...prev, _id: newSkillTreeId }));
+        skillTreeId = newSkillTreeId;
 
-     //Update the owner's created communities list
-      await Meteor.callAsync('updateCreatedCommunities', skillTreeId);
-      //Update the owner's subscribed communities list
-      await Meteor.callAsync('updateSubscribedCommunities', skilltreeId);
-      //Add skilltree progress --> this will execute the else condition
-      await Meteor.callAsync('saveSubscription', skillTreeId);
-      
-      // Add admin role
-      const updateOperation = { $addToSet: { roles: 'admin' } };
-      toast.success('Successfully created SkillTree!');
-    } else {
-      // Subsequent saves: update existing SkillTree
-      const updateData = { ...skilltreeToSave };      
-      console.log("Updating with data:", updateData);
-      
-      await Meteor.callAsync('skilltrees.update', skillTreeId, updateData);
+        //Update the owner's created communities list
+        await Meteor.callAsync('updateCreatedCommunities', skillTreeId);
+        //Update the owner's subscribed communities list
+        await Meteor.callAsync('updateSubscribedCommunities', skillTreeId);
+        //Add skilltree progress --> this will execute the else condition
+        await Meteor.callAsync('saveSubscription', skillTreeId);
+        //Add Admin role
+        await Meteor.callAsync('updateSkillTreeProgress', skillTreeId, userId, {
+          $addToSet: { roles: 'admin' }
+        });
 
-      // Update local state
-      setSkillTree(prev => ({
-        ...prev,
-        ...updateData,
-        updatedAt: new Date()
-      }));
-      // await Meteor.callAsync('updateCreatedCommunities', skillTreeId);
-      // await Meteor.callAsync('updateSubscribedCommunities', skillTreeId);
-      await Meteor.callAsync('saveSubscription', skillTreeId);
-      console.log("SkillTree updated successfully");
-      toast.success('SkillTree updated!');
+        // Add admin role
+        toast.success('Successfully created SkillTree!');
+      } else {
+        // Subsequent saves: update existing SkillTree
+        const updateData = { ...skilltreeToSave };
+        console.log('Updating with data:', updateData);
+
+        await Meteor.callAsync('skilltrees.update', skillTreeId, updateData);
+
+        // Update local state
+        setSkillTree(prev => ({
+          ...prev,
+          ...updateData,
+          updatedAt: new Date()
+        }));
+        // await Meteor.callAsync('updateCreatedCommunities', skillTreeId);
+        // await Meteor.callAsync('updateSubscribedCommunities', skillTreeId);
+        await Meteor.callAsync('saveSubscription', skillTreeId);
+        console.log('SkillTree updated successfully');
+        toast.success('SkillTree updated!');
+      }
+    } catch (error) {
+      console.error('Error saving skill tree:', error);
+      toast.error('Error saving SkillTree!');
     }
-  } catch (error) {
-    console.error('Error saving skill tree:', error);
-    toast.error('Error saving SkillTree!');
-  }
-};
+  };
 
   return (
     <>
@@ -161,7 +161,7 @@ export const CreateSkillTree = () => {
         {/* Conditionally render add skills form, Only pass nodes and edges if they exist*/}
         {showAddSkillsForm && skillTree.skillNodes.length > 0 && (
           <>
-            {console.log("Skilltree found and loaded")}
+            {console.log('Skilltree found and loaded')}
             {/* {console.log(skilltreeToSave)} */}
             <SkillTreeEdit
               isAdmin={true}
@@ -174,7 +174,7 @@ export const CreateSkillTree = () => {
         )}
         {showAddSkillsForm && skillTree.skillNodes.length == 0 && (
           <>
-            {console.log("0 Skill tree found")}
+            {console.log('0 Skill tree found')}
             {/* {console.log(skilltreeToSave)} */}
             <SkillTreeEdit
               isAdmin={true}

--- a/imports/ui/pages/CreateSkillTree.jsx
+++ b/imports/ui/pages/CreateSkillTree.jsx
@@ -89,60 +89,56 @@ export const CreateSkillTree = () => {
   };
 
   const handleSaveSkillTree = async skilltreeToSave => {
-    try {
-      let skilltreeId = skillTree._id;
+  // console.log("save clicked");
+  // console.log("Data to save:", skilltreeToSave);
+  
+  try {
+    let skillTreeId = skillTree._id;
 
-      if (!skilltreeId) {
-        // First save: insert new SkillTree
-        const newSkillTreeId = await Meteor.callAsync(
-          'skilltrees.insert',
-          skilltreeToSave
-        );
-        // Store the new ID
-        setSkillTree(prev => ({ ...prev, _id: newSkillTreeId })); 
-        skilltreeId = newSkillTreeId;
+    if (!skillTreeId) {
+      // First save: insert new SkillTree
+      const newSkillTreeId = await Meteor.callAsync(
+        'skilltrees.insert',
+        skilltreeToSave
+      );
+      // Store the new ID
+      setSkillTree(prev => ({ ...prev, _id: newSkillTreeId }));
+      skillTreeId = newSkillTreeId;
 
-      //Update the owner's created communities list
-      await Meteor.callAsync('updateCreatedCommunities', skilltreeId);
+     //Update the owner's created communities list
+      await Meteor.callAsync('updateCreatedCommunities', skillTreeId);
       //Update the owner's subscribed communities list
       await Meteor.callAsync('updateSubscribedCommunities', skilltreeId);
       //Add skilltree progress --> this will execute the else condition
-      await Meteor.callAsync('saveSubscription', skilltreeId);
-      //Add admin role to skilltree progression
-      const updateOperation = {
-        $addToSet: { roles: 'admin' }
-
-      };
-
-      await Meteor.callAsync(
-        'updateSkillTreeProgress',
-        skilltreeId,
-        userId,
-        updateOperation
-      );
-
-      navigate('/dashboard', { state: { showSkillTreeCreatedToast: true } });
-
-      console.log('Skill Tree saved successfully');
+      await Meteor.callAsync('saveSubscription', skillTreeId);
+      
+      // Add admin role
+      const updateOperation = { $addToSet: { roles: 'admin' } };
       toast.success('Successfully created SkillTree!');
-      } else {
-        // Subsequent saves: update existing SkillTree
-        const { _id, ...updateData } = skilltreeToSave; // Exclude _id from update data
-        await Meteor.callAsync('skilltrees.update', skillTreeId, updateData);
+    } else {
+      // Subsequent saves: update existing SkillTree
+      const updateData = { ...skilltreeToSave };      
+      console.log("Updating with data:", updateData);
+      
+      await Meteor.callAsync('skilltrees.update', skillTreeId, updateData);
 
-        setSkillTree(prev => ({
-          ...prev,
-          ...updateData,
-          updatedAt: new Date()
-        }));
-
-        toast.success('SkillTree updated!');
-      }
-    } catch (error) {
-      console.error('Error saving skill tree:', error);
-      toast.error('Error saving SkillTree!');
+      // Update local state
+      setSkillTree(prev => ({
+        ...prev,
+        ...updateData,
+        updatedAt: new Date()
+      }));
+      // await Meteor.callAsync('updateCreatedCommunities', skillTreeId);
+      // await Meteor.callAsync('updateSubscribedCommunities', skillTreeId);
+      await Meteor.callAsync('saveSubscription', skillTreeId);
+      console.log("SkillTree updated successfully");
+      toast.success('SkillTree updated!');
     }
-  };
+  } catch (error) {
+    console.error('Error saving skill tree:', error);
+    toast.error('Error saving SkillTree!');
+  }
+};
 
   return (
     <>
@@ -165,6 +161,8 @@ export const CreateSkillTree = () => {
         {/* Conditionally render add skills form, Only pass nodes and edges if they exist*/}
         {showAddSkillsForm && skillTree.skillNodes.length > 0 && (
           <>
+            {console.log("Skilltree found and loaded")}
+            {/* {console.log(skilltreeToSave)} */}
             <SkillTreeEdit
               isAdmin={true}
               onSave={updateNodesAndEdges}
@@ -176,6 +174,8 @@ export const CreateSkillTree = () => {
         )}
         {showAddSkillsForm && skillTree.skillNodes.length == 0 && (
           <>
+            {console.log("0 Skill tree found")}
+            {/* {console.log(skilltreeToSave)} */}
             <SkillTreeEdit
               isAdmin={true}
               onSave={updateNodesAndEdges}


### PR DESCRIPTION

# Summary

- Fixed bug where saving tree on tree creation would only keep the first save state
- Fixed bug where 2 trees would be created after clicking save during creation
- Fix bug with new node being added on save in some instances
- Fix save button to now keep most recent saved state
- Add ability for admins to edit existing trees
- Add Edit and View mode for tree editing/creation for admins
- Add proper node type rendering based on roles
- Refactor skill nodes to use upvotes during render rather than previous implementation of XP
- Refactor existing trees and dummy subscriptions to include child property
- Add locked nodes being rendered as different colour with text describing locked status


# Related Issues:
Bug fixes


# Type of change
Bug fixes + Clean up/extend existing features


# How Has This Been Tested?
User testing:
- During tree creation make multiple saves. Should update to newest save
- As admin, go into existing tree and make new save. Should update to newest save
- As normal member view tree. Should see locked nodes
- As admin go into existing or create new tree. Should see buttons for edit and view with different functionality
