### PR TITLE
Fix a bug where by default the sample user has an active subscription…

### DIFF
--- a/imports/api/publications/Users.js
+++ b/imports/api/publications/Users.js
@@ -287,6 +287,9 @@ Meteor.startup(async () => {
     communityMemberA
   );
 
+  // There is a hardcoded subscription object for sampleId and basketball, so we need to run this method to ensure consistency with the subscribers list.
+  await Meteor.callAsync('skilltrees.subscribeUser', 'basketball', sampleId);
+
   //Sample Dummy skilltree progress
   for (const progressTree of dummyProgressTree) {
     var copyProgressTree1 = { ...progressTree };


### PR DESCRIPTION
Fix a bug where by default the sample user has an active subscription for the Basketball skilltree, but is not in the list of subscribers for that skilltree
- Fixes inability to join Basketball skilltree
- Fixes the subscribe button showing that the user is not subscribed while they can still do subscriber-only things