### PR TITLE
Resolve SSR Edge Cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -1646,13 +1646,13 @@ tests/					<Unit Tests>
 >
 > Hydration mismatches from certain subscribed data mismatching on page load/refresh (SSR) can be opt-out by wrapping around the display of the mismatched data with the custom `<SuspenseHydrated>` component in place of regular `<Suspense>` as a workaround along with the `fadeInEffect` or `popInEffect` classes to smooth out the fallback transition.
 >
-> There are 2-3 edge cases with SSR of hydration mismatches which should opt-out:
+> There are 3 possible edge cases known with SSR on hydration mismatches which should opt-out if the suggested resolution does not work:
 >
 > <details>
 > <summary>⋯</summary>
 >
-> - *Non useFind hook usage such as meteor methods calls to fetch data from the DB may not server render properly. All such usage should opt-out of SSR as a stopgap where it should ideally be transitioned to useFind if possible*.
-> - Modifying fetch result data from useFind such as sorting the array of IDs will result in a mismatch between the server (non modified) and client (modified on hydration, sorted etc). All such usage should be done via [aggregation operators](https://www.mongodb.com/docs/manual/reference/operator/aggregation/sort/) when possible otherwise opt-out of SSR.
+> - Non useFind hook usage such as meteor methods calls to fetch data from the DB may not server render properly and mismatch. *All such usage should opt-out of SSR as a stopgap where* **it should ideally be transitioned to useFind if possible as the resolution**.
+> - Displaying a list of fetch result data (map IDs) from useFind may mismatch between the server (reversed order) and client (natural order). **The resolution is to explicitly sort in the useFind options via `useFind(COLLECTION, { MongoSelector... }, { options..., sort: { _id: 1 } })`** *otherwise opt-out of SSR if it does not resolve the issue.*
 > - Datetime locale mismatches on server and client due to timezone differences, all such usage should opt-out of SSR.
 >
 > > ```jsx

--- a/README.md
+++ b/README.md
@@ -241,9 +241,11 @@ imports/
 │   └── Root.jsx             	// Root JSX Container
 ├── utils/                	<Utility Helper Functions/Hooks>
 │   ├── contexts/          		// React Contexts
-│   └── providers/          	// React Providers
-│   └── RouteGuard.jsx      	// Route Protection & Redirects
-│   └── SuspenseHydrated.jsx	// Suspense Opt Out SSR
+│   ├── providers/            	// React Providers
+│   ├── Locale.jsx            	// toLocale (SSR Workaround)
+│   ├── PreHydration.jsx      	// injectPreHydration (SSR Workaround)
+│   ├── RouteGuard.jsx      	// Route Protection & Redirects
+│   ├── SuspenseHydrated.jsx	// Suspense (SSR Opt Out Workaround)
 │   └── User.jsx				// User Utils (Fetch LoggedIn User)
 └── Router.js             	// Router on Client (SPA) & Server (SSR)
 private/                <Server Assets>
@@ -1637,30 +1639,28 @@ tests/					<Unit Tests>
 >
 >   The custom implementation uses `renderToNodeStream` to work with React suspense on Meteor's pub/sub because `renderToPipeableStream` does not work with Meteor `v3.3.2` yet [[1](https://forums.meteor.com/t/can-we-already-use-suspense-with-meteor-3/62677/2)] [[2](https://forums.meteor.com/t/can-we-already-use-suspense-with-meteor-3/62677/4)] [[3](https://forums.meteor.com/t/ssr-with-meteor-callasync/60979/24)]. This may change in the future but it is the only option at this time.
 >
-> - Hydration mismatches. See the next section SuspenseHydrated (SSR Opt-Out) for details.
+> - **Hydration mismatches**. There are 3 possible edge cases known with SSR on hydration mismatches which all can be resolved or selectively opt-out of SSR as the last resort if the suggested resolutions does not work to workaround the issue:
+>     - Non useFind hook usage such as meteor methods calls or useTracker to fetch data from the DB may not server render properly and mismatch. *All such usage* **should ideally be transitioned to useFind if possible as the resolution** *otherwise may opt-out of SSR as the last resort stopgap.*
+>     - Displaying a list of fetch result data (map IDs) from useFind may mismatch between the server (reversed order) and client (natural order). **The resolution is to explicitly sort in the useFind options via `useFind(COLLECTION, { MongoSelector... }, { options..., sort: { _id: 1 } })`** *otherwise opt-out of SSR as the last resort if it does not resolve the issue.*
+>     - Datetime locale mismatches on server and client due to timezone differences. *All such usage* **should utilise `toLocale()` utils that uses the custom `injectPreHydration(...)` under the hood to resolve the issue**.
+>
 > </details>
 
-#### SuspenseHydrated (SSR Opt-Out)
+#### SuspenseHydrated (SSR Opt-Out Workaround)
 
 > [!TIP]
 >
-> Hydration mismatches from certain subscribed data mismatching on page load/refresh (SSR) can be opt-out by wrapping around the display of the mismatched data with the custom `<SuspenseHydrated>` component in place of regular `<Suspense>` as a workaround along with the `fadeInEffect` or `popInEffect` classes to smooth out the fallback transition.
->
-> There are 3 possible edge cases known with SSR on hydration mismatches which should opt-out if the suggested resolution does not work:
+> Hydration mismatches from certain subscribed data mismatching on page load/refresh (SSR) can be opt-out as the last resort by wrapping around the display of the mismatched data with the custom `<SuspenseHydrated>` component in place of regular `<Suspense>` as a workaround along with the `fadeInEffect` or `popInEffect` classes to smooth out the fallback transition:
 >
 > <details>
 > <summary>⋯</summary>
->
-> - Non useFind hook usage such as meteor methods calls to fetch data from the DB may not server render properly and mismatch. *All such usage should opt-out of SSR as a stopgap where* **it should ideally be transitioned to useFind if possible as the resolution**.
-> - Displaying a list of fetch result data (map IDs) from useFind may mismatch between the server (reversed order) and client (natural order). **The resolution is to explicitly sort in the useFind options via `useFind(COLLECTION, { MongoSelector... }, { options..., sort: { _id: 1 } })`** *otherwise opt-out of SSR if it does not resolve the issue.*
-> - Datetime locale mismatches on server and client due to timezone differences, all such usage should opt-out of SSR.
->
+> 
 > > ```jsx
 > > import { SuspenseHydrated } from '/imports/utils/SuspenseHydrated';
 > > ...
 > > <SuspenseHydrated fallback={'Loading'}>
 > >   <div className="fadeInEffect">
-> >     { new Date().toLocaleString(); }
+> >     { MISMATCHED_DATA OR } <Component /> 
 > >     ...
 > >   </div>
 > > </SuspenseHydrated>

--- a/README.md
+++ b/README.md
@@ -1687,6 +1687,61 @@ tests/					<Unit Tests>
 > > ```
 > > </details>
 
+#### toLocale (SSR DateTime Locale Mismatch Resolution)
+
+> [!TIP]
+>
+> Custom `toLocale()` helper function to convert datetime to locale strings that works with SSR as the server render would normally use the server's locale and datetime that may be different to the client which will cause a hydration mismatch:
+>
+> <details>
+> <summary>⋯</summary>
+>
+> It resolves this issue under the hood by utilising the custom `injectPreHydration()` utils to delay any datetime locale code from executing on the server render by serialising as `<script>` to instead run on the client browser before hydration to match with the client render.
+>
+> > `toLocale(dateObj, format, options, locales)`
+> >
+> > ```jsx
+> > import { toLocale } from '/imports/utils/Locale.jsx';
+> > ...
+> > toLocale(
+> >   dateObj, // Date Object
+> >   format = 'DateTime', // 'DateTime', 'Date', 'Time', 'DateTimeShort', 'DateLong', 'DateTimeLong' -- Long formats dateStyle: 'long'
+> >   options = { dateStyle: 'short', timeStyle: 'short' }, // Format options, overridable but can just be omitted
+> >   locales = '' // User's locale, overridable but can just be omitted
+> > );
+> > ```
+> >
+> > - **format** parameter is the predefined style (`'DateTime'`, `'Date'`, `'Time'`, `'DateTimeShort'`, `'DateLong'`, `'DateTimeLong'`) to format the string but can be overridden by passing the options and also locale from the `Intl.DateTimeFormat` API, refer to the [docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString#parameters).
+> >   - It first automatically determines which string method for the locale to use:
+> >     - `toLocaleString()` for **`'DateTime'`**, `'DateTimeShort'`, `'DateTimeLong'`, `(omitted)`
+> >     - `toLocaleDateString()` for  **`'Date'`**, `'DateLong'`
+> >     - `toLocaleTimeString()` for **`'Time'`**
+> >   - It then automatically sets options to predefined styles:
+> >     - `{ dateStyle: 'short', timeStyle: 'short' }` for `'DateTime'`,  `(omitted)`
+> >     - `{ dateStyle: 'long', timeStyle: 'short' }` for `'DateTimeLong'`
+> >     - `{ dateStyle: 'short' }` for `'Date'` 
+> >     - `{ dateStyle: 'long' }` for `'DateLong'`
+> >     - `{ timeStyle: 'short'}` for `'Time'`
+> >     - `{ year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' }` for `'DateTimeShort'`
+> >
+> > **Examples:**
+> >
+> > ```jsx
+> > import { toLocale } from '/imports/utils/Locale.jsx';
+> > ...
+> > const dateObj = new Date('2036-08-12');
+> > toLocale(dateObj); // 12/8/36, 12:00 am
+> > toLocale(dateObj, 'DateTime'); // 12/8/36, 12:00 am
+> > toLocale(dateObj, 'Date'); // 12/8/36
+> > toLocale(dateObj, 'Time'); // 12:00 am
+> > toLocale(dateObj, 'DateTimeShort'); // 12 Aug 2036, 12:00 am
+> > toLocale(dateObj, 'DateTimeLong'); // 12 August 2036 at 12:00 am
+> > toLocale(dateObj, 'DateTime', {}); // 12/08/2036, 12:00:00 am
+> > toLocale(dateObj, 'DateTime', { month: 'short', hour: '2-digit' }, 'en-AU'); // Aug, 12 am
+> > ```
+>
+> </details>
+
 #### SuspenseHydrated (SSR Opt-Out Workaround)
 
 > [!TIP]

--- a/README.md
+++ b/README.md
@@ -1646,6 +1646,47 @@ tests/					<Unit Tests>
 >
 > </details>
 
+#### injectPreHydration (SSR Mismatch Resolution)
+
+> [!TIP]
+>
+> Custom helper function to inject content from an input function (as `setContentFn`) on the client for the server render before hydration to resolve mismatches on client with SSR edge cases such as datetime locale differing on the server and client: 
+>
+> <details>
+> <summary>⋯</summary>
+>
+> It delays setContentFn on the server render by serialising the function as an inline `<script>` so that it is executed on the client browser immediately before hydration to match with the client's `setContentFn` (without `<script>`) on hydration. Sanitised via `serialize-javascript` to reduce XSS potential on `setContentFn`'s arguments. Any variables declared within the function will be initialised on the client browser which is intended for the mismatch culprit such as new date objects, `navigator.languages` and `toLocaleString` methods. The function serialisation causes variables declared outside the function to lose its values (unscoped) that were initialised and set on the server. Such `dependencies` is the object of all `varName: varValue` used to substitute each `varName` occurrence in `setContentFn` with its `varValue` in the inline script since serialising a function loses its original scope values if it was declared outside the function.
+>
+> > **`injectPreHydration(setContentFn, dependencies)`**:
+> >
+> > ```jsx
+> > import { injectPreHydration } from '/imports/utils/PreHydration';
+> > ...
+> > injectPreHydration(
+> >   setContentFn, // function that sets the content before hydration to be serialized within inline script and when hydrated to match the same
+> >   dependencies = {}, // object of {varName: varValue, ...} for unscoped variables dependencies on function serialization variable value substitution
+> >   wrapSpan = false // whether the content should be wrapped with <span>...</span>, set as true to fix DOM structure hydration mismatch by ensuring both results are within same structure
+> > );
+> > ```
+> > **Example:**
+> >
+> > ```jsx
+> > import { injectPreHydration } from '/imports/utils/PreHydration';
+> > ...
+> > const userTime = unit => // unit is either 'hour' or 'minute'
+> >   injectPreHydration(
+> >     () => { // The function to set the content delayed to run on client browser before hydration and after
+> >       const isHour = unit === 'hour'; // unit becomes unscoped from its value on function serialiation
+> >       const currentDateTime = new Date() // The mismatch culprit to run in client browser rather than server
+> >
+> >       return isHour ? currentDateTime.getHours() : currentDateTime.getMinutes();
+> >     },
+> >     { unit }, // pass unit as the unscoped variables dependencies on function serialization
+> >     true // optional wrapSpan to ensure consistent DOM structure, needed only on per case basis
+> >   );
+> > ```
+> > </details>
+
 #### SuspenseHydrated (SSR Opt-Out Workaround)
 
 > [!TIP]
@@ -1654,7 +1695,7 @@ tests/					<Unit Tests>
 >
 > <details>
 > <summary>⋯</summary>
-> 
+>
 > > ```jsx
 > > import { SuspenseHydrated } from '/imports/utils/SuspenseHydrated';
 > > ...

--- a/imports/api/publications/Users.js
+++ b/imports/api/publications/Users.js
@@ -6,35 +6,7 @@ import { SubscriptionsCollection } from '/imports/api/collections/Subscriptions'
 import '/imports/api/schemas/Users'; // Enable Users Schema Validation
 
 // Publish the publication named as "users" from the backend, lets clients (front-end JSX) subscribe to the data for real time changes
-Meteor.publish('users', () => Meteor.users.find()); // Note: this is only intended for ProfileCompleteRoute, utils/User should be used instead.
-Meteor.publish('user', () => {
-  if (this.userId) {
-    return Meteor.users.find(
-      { _id: this.userId },
-      {
-        fields: { username: 1, emails: 1, profile: 1 }
-      }
-    );
-  } else {
-    this.ready();
-  }
-});
-
-Meteor.publish('usernames', function (userIds) {
-  if (!userIds) {
-    return this.ready();
-  }
-
-  return Meteor.users.find(
-    { _id: { $in: userIds } },
-    {
-      fields: {
-        username: 1,
-        profile: 1
-      }
-    }
-  );
-});
+Meteor.publish('users', () => Meteor.users.find());
 
 const dummyProgressTree = [
   {

--- a/imports/ui/components/Community/Management/Cards/ExpertApplicationCard.jsx
+++ b/imports/ui/components/Community/Management/Cards/ExpertApplicationCard.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { SuspenseHydrated } from '/imports/utils/SuspenseHydrated';
+import { toLocale } from '/imports/utils/Locale.jsx';
 
 /*
 The fields and questions asked to the user in the moderator/expert form will be refactored later.
@@ -21,16 +21,7 @@ export const ExpertApplicationCard = ({ application, onReview }) => {
           </div>
           <p className="text-gray-600 text-sm mb-2">{application.email}</p>
           <div className="text-gray-500 text-sm mb-3">
-            Applied on{' '}
-            <SuspenseHydrated>
-              {new Date(application.createdAt).toLocaleDateString(undefined, {
-                year: 'numeric',
-                month: 'short',
-                day: 'numeric',
-                hour: '2-digit',
-                minute: '2-digit'
-              })}
-            </SuspenseHydrated>
+            Applied on {toLocale(application.createdAt, 'DateTimeShort')}
           </div>
 
           <div className="space-y-2">

--- a/imports/ui/components/Community/Management/Cards/ModeratorApplicationCard.jsx
+++ b/imports/ui/components/Community/Management/Cards/ModeratorApplicationCard.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { SuspenseHydrated } from '/imports/utils/SuspenseHydrated';
-
+import { toLocale } from '/imports/utils/Locale.jsx';
 /*
 The fields and questions asked to the user in the moderator/expert form will be refactored later.
 Thus, for now, we create a separate component for this for easier modification in the future.
@@ -20,16 +19,7 @@ export const ModeratorApplicationCard = ({ application, onReview }) => {
           </div>
           <p className="text-gray-600 text-sm mb-2">{application.email}</p>
           <div className="text-gray-500 text-sm mb-3">
-            Applied on{' '}
-            <SuspenseHydrated>
-              {new Date(application.createdAt).toLocaleDateString(undefined, {
-                year: 'numeric',
-                month: 'short',
-                day: 'numeric',
-                hour: '2-digit',
-                minute: '2-digit'
-              })}
-            </SuspenseHydrated>
+            Applied on {toLocale(application.createdAt, 'DateTimeShort')}
           </div>
 
           <div className="space-y-2">

--- a/imports/ui/components/Community/Management/ReviewApplication.jsx
+++ b/imports/ui/components/Community/Management/ReviewApplication.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { SuspenseHydrated } from '/imports/utils/SuspenseHydrated';
+import { toLocale } from '/imports/utils/Locale.jsx';
 
 export const ReviewApplication = ({
   selectedApplication,
@@ -74,15 +74,7 @@ export const ReviewApplication = ({
               Application Date
             </label>
             <div className="px-3 py-2 bg-gray-50 border border-gray-300 rounded-lg text-gray-900">
-              <SuspenseHydrated>
-                {selectedApplication.createdAt.toLocaleDateString(undefined, {
-                  year: 'numeric',
-                  month: 'short',
-                  day: 'numeric',
-                  hour: '2-digit',
-                  minute: '2-digit'
-                })}
-              </SuspenseHydrated>
+              {toLocale(selectedApplication.createdAt, 'DateTimeShort')}
             </div>
           </div>
         </div>

--- a/imports/ui/components/Dashboard/Greeting.jsx
+++ b/imports/ui/components/Dashboard/Greeting.jsx
@@ -1,4 +1,3 @@
-import { Meteor } from 'meteor/meteor';
 import React from 'react';
 import { injectPreHydration } from '/imports/utils/PreHydration';
 

--- a/imports/ui/components/Dashboard/Greeting.jsx
+++ b/imports/ui/components/Dashboard/Greeting.jsx
@@ -1,10 +1,12 @@
+import { Meteor } from 'meteor/meteor';
 import React from 'react';
+import serialize from 'serialize-javascript';
 
 const getGreeting = type => {
-  const isIcon = type === 'icon';
-  const currHour = new Date().getHours();
-
   const greeting = () => {
+    const isIcon = type === 'icon';
+    const currHour = new Date().getHours();
+
     if (currHour >= 5 && currHour < 12) {
       return isIcon ? '🌅' : 'Good morning';
     } else if (currHour >= 12 && currHour < 17) {
@@ -16,7 +18,29 @@ const getGreeting = type => {
     }
   };
 
-  return greeting();
+  // Define client side inline script as literal string to inject before hydration, sanitised via serialize-javascript
+  const inlineScript = `
+    (function() {
+      const script = document.currentScript; // Reference to this <script> element on the DOM
+      
+      // Set value before <script> using the client's browser time rather than the server's
+      script && (script.before(
+        (${serialize(greeting).replace('()=>', 'function() ').replace('type', serialize(type))})()
+      ));
+      
+      // Remove itself <script> to clean up DOM and avoid hydration mismatch
+      script && script.remove();
+    })();
+  `;
+
+  return (
+    <>
+      {Meteor.isClient && greeting()}
+      {Meteor.isServer && (
+        <script dangerouslySetInnerHTML={{ __html: inlineScript }} />
+      )}
+    </>
+  );
 };
 
 export const getGreetingMessage = () => getGreeting('message');

--- a/imports/ui/components/Dashboard/Greeting.jsx
+++ b/imports/ui/components/Dashboard/Greeting.jsx
@@ -1,47 +1,26 @@
 import { Meteor } from 'meteor/meteor';
 import React from 'react';
-import serialize from 'serialize-javascript';
+import { injectPreHydration } from '/imports/utils/PreHydration';
 
-const getGreeting = type => {
-  const greeting = () => {
-    const isIcon = type === 'icon';
-    const currHour = new Date().getHours();
+const getGreeting = type =>
+  injectPreHydration(
+    () => {
+      const isIcon = type === 'icon';
+      const currHour = new Date().getHours();
 
-    if (currHour >= 5 && currHour < 12) {
-      return isIcon ? '🌅' : 'Good morning';
-    } else if (currHour >= 12 && currHour < 17) {
-      return isIcon ? '☀️' : 'Good afternoon';
-    } else if (currHour >= 17 && currHour < 21) {
-      return isIcon ? '🌆' : 'Good evening';
-    } else {
-      return isIcon ? '🌙' : 'Good night';
-    }
-  };
-
-  // Define client side inline script as literal string to inject before hydration, sanitised via serialize-javascript
-  const inlineScript = `
-    (function() {
-      const script = document.currentScript; // Reference to this <script> element on the DOM
-      
-      // Set value before <script> using the client's browser time rather than the server's
-      script && (script.before(
-        (${serialize(greeting).replace('()=>', 'function() ').replace('type', serialize(type))})()
-      ));
-      
-      // Remove itself <script> to clean up DOM and avoid hydration mismatch
-      script && script.remove();
-    })();
-  `;
-
-  return (
-    <>
-      {Meteor.isClient && greeting()}
-      {Meteor.isServer && (
-        <script dangerouslySetInnerHTML={{ __html: inlineScript }} />
-      )}
-    </>
+      if (currHour >= 5 && currHour < 12) {
+        return isIcon ? '🌅' : 'Good morning';
+      } else if (currHour >= 12 && currHour < 17) {
+        return isIcon ? '☀️' : 'Good afternoon';
+      } else if (currHour >= 17 && currHour < 21) {
+        return isIcon ? '🌆' : 'Good evening';
+      } else {
+        return isIcon ? '🌙' : 'Good night';
+      }
+    },
+    { type }, // pass unscoped variables dependencies on function serialization
+    true // wrapSpan
   );
-};
 
 export const getGreetingMessage = () => getGreeting('message');
 export const getGreetingIcon = () => getGreeting('icon');

--- a/imports/ui/components/Dashboard/Greeting.jsx
+++ b/imports/ui/components/Dashboard/Greeting.jsx
@@ -1,29 +1,23 @@
 import React from 'react';
 
-export const getGreetingMessage = () => {
+const getGreeting = type => {
+  const isIcon = type === 'icon';
   const currHour = new Date().getHours();
 
-  if (currHour >= 5 && currHour < 12) {
-    return 'Good morning';
-  } else if (currHour >= 12 && currHour < 17) {
-    return 'Good afternoon';
-  } else if (currHour >= 17 && currHour < 21) {
-    return 'Good evening';
-  } else {
-    return 'Good night';
-  }
+  const greeting = () => {
+    if (currHour >= 5 && currHour < 12) {
+      return isIcon ? '🌅' : 'Good morning';
+    } else if (currHour >= 12 && currHour < 17) {
+      return isIcon ? '☀️' : 'Good afternoon';
+    } else if (currHour >= 17 && currHour < 21) {
+      return isIcon ? '🌆' : 'Good evening';
+    } else {
+      return isIcon ? '🌙' : 'Good night';
+    }
+  };
+
+  return greeting();
 };
 
-export const getGreetingIcon = () => {
-  const currHour = new Date().getHours();
-
-  if (currHour >= 5 && currHour < 12) {
-    return '🌅';
-  } else if (currHour >= 12 && currHour < 17) {
-    return '☀️';
-  } else if (currHour >= 17 && currHour < 21) {
-    return '🌆';
-  } else {
-    return '🌙';
-  }
-};
+export const getGreetingMessage = () => getGreeting('message');
+export const getGreetingIcon = () => getGreeting('icon');

--- a/imports/ui/components/GeneralForum.jsx
+++ b/imports/ui/components/GeneralForum.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
+import { toLocale } from '/imports/utils/Locale.jsx';
 
 export const GeneralForum = () => {
   const { skilltreeId } = useParams(); // <-- Get skilltreeId from URL
@@ -69,7 +70,7 @@ export const GeneralForum = () => {
               <div className="font-semibold">{msg.username}</div>
               <div className="text-gray-700">{msg.text}</div>
               <div className="text-xs text-gray-400">
-                {msg.createdAt.toLocaleString()}
+                {toLocale(msg.createdAt)}
               </div>
             </div>
           </div>

--- a/imports/ui/components/Proofs/Comments/CommentSection.jsx
+++ b/imports/ui/components/Proofs/Comments/CommentSection.jsx
@@ -3,6 +3,7 @@ import { CommentsCollection } from '/imports/api/collections/Comments';
 import { useSubscribe, useFind } from 'meteor/react-meteor-data/suspense';
 import { Meteor } from 'meteor/meteor';
 import { User } from '/imports/utils/User';
+import { toLocale } from '/imports/utils/Locale.jsx';
 
 /**
  * Component that displays all comments for a given proof.
@@ -27,16 +28,6 @@ export const CommentSection = ({ proofId }) => {
   const [editingComment, setEditingComment] = useState('');
   // The current text value of the comment being updated, continuously updated as you edit
   const [currentText, setCurrentText] = useState('');
-
-  // Format date to be more readable
-  const formatDate = date => {
-    return date.toLocaleString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit'
-    });
-  };
 
   /**
    * Initiates the edit process
@@ -108,7 +99,12 @@ export const CommentSection = ({ proofId }) => {
             <strong>{item.username}</strong>
 
             <span style={{ fontSize: '0.8rem', color: '#666' }}>
-              {formatDate(item.createdAt)}
+              {toLocale(item.createdAt, 'DateTime', {
+                month: 'short',
+                day: 'numeric',
+                hour: '2-digit',
+                minute: '2-digit'
+              })}
             </span>
           </div>
           {/* If this comment is being edited, show an edit box and submit button, else show the comment and an edit button */}

--- a/imports/ui/components/Proofs/ProofDetails.jsx
+++ b/imports/ui/components/Proofs/ProofDetails.jsx
@@ -11,6 +11,7 @@ import { AddComment } from './Comments/AddComment';
 import { CommentSection } from './Comments/CommentSection';
 import { VoteButtons } from './Votes/VoteButtons';
 import { ProofCollection } from '/imports/api/collections/Proof';
+import { toLocale } from '/imports/utils/Locale.jsx';
 
 /**
  * Displays a modal popup with full details of a selected proof.
@@ -40,20 +41,6 @@ export const ProofDetails = ({ proofId, onClose }) => {
       }
     }
   ])[0];
-
-  /**
-   * Formats a JavaScript Date object into a human-readable string.
-   * @param {Date|string} date
-   * @returns {string}
-   */
-  const formatDate = date =>
-    new Date(date).toLocaleString(undefined, {
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit'
-    });
 
   // Return nothing if data proof doesn't exist
   if (!proof) return null;
@@ -85,7 +72,7 @@ export const ProofDetails = ({ proofId, onClose }) => {
           <div className="w-1/2 overflow-y-auto pr-4">
             <h2 className="text-xl font-semibold mb-1">{proof.title}</h2>
             <p className="text-sm text-gray-500">
-              by {proof.username} | {formatDate(proof.date)}
+              by {proof.username} | {toLocale(proof.date, 'DateTimeShort')}
             </p>
             <p className="text-gray-600 mt-2">
               Subskill: <strong>{proof.subskill}</strong>

--- a/imports/ui/components/Proofs/ProofsList.jsx
+++ b/imports/ui/components/Proofs/ProofsList.jsx
@@ -5,8 +5,10 @@ import React, { useState } from 'react';
 import { Meteor } from 'meteor/meteor';
 import { useFind, useSubscribe } from 'meteor/react-meteor-data/suspense';
 
+// Utils imports
+import { toLocale } from '/imports/utils/Locale.jsx';
+
 // Collections & Components
-import { SuspenseHydrated } from '../../../utils/SuspenseHydrated';
 import { ProofDetails } from './ProofDetails';
 import { VoteButtons } from './Votes/VoteButtons';
 import { ProofCollection } from '/imports/api/collections/Proof';
@@ -62,22 +64,6 @@ export const ProofsList = ({ skilltreeId, userRoles = [] }) => {
   // Empty state UI
   if (proofs.length === 0) return <div>No proofs found.</div>;
 
-  /**
-   * Formats a given date into a human-readable string.
-   * E.g., "28 May 2025, 03:15 PM"
-   */
-  const formatDate = date => {
-    if (!date) return '';
-    const d = new Date(date);
-    return d.toLocaleDateString(undefined, {
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit'
-    });
-  };
-
   const handleVerify = proofId => {
     Meteor.call('proof.verify', proofId, error => {
       if (error) console.error('Verify failed:', error.reason);
@@ -108,12 +94,9 @@ export const ProofsList = ({ skilltreeId, userRoles = [] }) => {
                     )}
                     <span>{proof.username}</span>
                   </span>
-                  {/* Opt out of SSR due to datetime mismatching on server and client hydration */}
-                  <SuspenseHydrated>
-                    <span className="text-xs italic popInEffect">
-                      {formatDate(proof.date)}
-                    </span>
-                  </SuspenseHydrated>
+                  <span className="text-xs italic popInEffect">
+                    {toLocale(proof.date, 'DateTimeShort')}
+                  </span>
                 </div>
 
                 {/* Subskill Tag */}

--- a/imports/ui/components/RankedEvents/EventCard.jsx
+++ b/imports/ui/components/RankedEvents/EventCard.jsx
@@ -4,8 +4,10 @@ import React from 'react';
 // Meteor-specific imports
 import { useFind, useSubscribe } from 'meteor/react-meteor-data/suspense';
 
+// Utils imports
+import { toLocale } from '/imports/utils/Locale.jsx';
+
 // Collections & Components
-import { SuspenseHydrated } from '../../../utils/SuspenseHydrated';
 import { VoteUpButton } from './VoteUpButton';
 import { ProofCollection } from '/imports/api/collections/Proof';
 import { User } from '/imports/utils/User';
@@ -61,22 +63,6 @@ export const EventCard = ({ eventId, skilltreeId, filter = 'default' }) => {
   // Empty state UI
   if (sortedProofs.length === 0) return <div>No proofs found.</div>;
 
-  /**
-   * Formats a given date into a human-readable string.
-   * E.g., "28 May 2025, 03:15 PM"
-   */
-  const formatDate = date => {
-    if (!date) return '';
-    const d = new Date(date);
-    return d.toLocaleDateString(undefined, {
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit'
-    });
-  };
-
   return (
     <div className="min-h-screen bg-white py-6 px-4 sm:px-6 lg:px-8">
       <div className="w-full max-w-screen-2xl mx-auto">
@@ -93,12 +79,9 @@ export const EventCard = ({ eventId, skilltreeId, filter = 'default' }) => {
                     )}
                     <span>{proof.username}</span>
                   </span>
-                  {/* Opt out of SSR due to datetime mismatching on server and client hydration */}
-                  <SuspenseHydrated>
-                    <span className="text-xs italic popInEffect">
-                      {formatDate(proof.date)}
-                    </span>
-                  </SuspenseHydrated>
+                  <span className="text-xs italic popInEffect">
+                    {toLocale(proof.date, 'DateTimeShort')}
+                  </span>
                 </div>
 
                 {/* Evidence Image Preview */}

--- a/imports/ui/components/SkillTrees/Leaderboard/CommunityLeaderboardList.jsx
+++ b/imports/ui/components/SkillTrees/Leaderboard/CommunityLeaderboardList.jsx
@@ -101,7 +101,7 @@ export const CommunityLeaderboardList = ({ skilltreeId, filter }) => {
 
   const subscriberIds = targetSkillTree?.subscribers ?? [];
 
-  useSubscribe('usernames', subscriberIds);
+  useSubscribe('users', subscriberIds);
   const users = useFind(
     Meteor.users,
     [{ _id: { $in: subscriberIds } }, { fields: { username: 1, _id: 1 } }],

--- a/imports/ui/layouts/DashboardSkillTrees.jsx
+++ b/imports/ui/layouts/DashboardSkillTrees.jsx
@@ -24,7 +24,8 @@ export const DashboardSkillTrees = () => {
   const allSkillTrees = useFind(SkillTreeCollection, [
     { _id: { $in: allUniqueIds } },
     {
-      fields: { _id: 1, owner: 1 }
+      fields: { _id: 1, owner: 1 },
+      sort: { _id: 1 }
     }
   ]).filter(Boolean); //Some elements were null, so we filter out any null results
 
@@ -36,14 +37,14 @@ export const DashboardSkillTrees = () => {
       user?.profile?.subscribedCommunities?.includes(skillTree._id) || false
   }));
 
-  const displayedSkillTrees = skillTreesWithRoles.slice(0, 6);
-
   // Sort by ownership first, then by join date or creation date
   const sortedSkillTrees = [...skillTreesWithRoles].sort((a, b) => {
     if (a.isOwner && !b.isOwner) return -1;
     if (!a.isOwner && b.isOwner) return 1;
     return new Date(b.createdAt) - new Date(a.createdAt);
   });
+
+  const displayedSkillTrees = sortedSkillTrees.slice(0, 6);
 
   return (
     <>

--- a/imports/ui/pages/Dashboard.jsx
+++ b/imports/ui/pages/Dashboard.jsx
@@ -167,12 +167,10 @@ export const Dashboard = () => {
 
           {currentView === 'skillTrees' && (
             <div className="mb-8 w-full">
-              <SuspenseHydrated fallback={<DashboardLoadingState />}>
-                <DashboardSkillTrees
-                  key={user._id}
-                  setCommunitiesCount={setCommunitiesCount}
-                />
-              </SuspenseHydrated>
+              <DashboardSkillTrees
+                key={user._id}
+                setCommunitiesCount={setCommunitiesCount}
+              />
             </div>
           )}
 

--- a/imports/ui/pages/Dashboard.jsx
+++ b/imports/ui/pages/Dashboard.jsx
@@ -1,3 +1,4 @@
+import { Meteor } from 'meteor/meteor';
 import React, { Suspense, useState, useEffect } from 'react';
 import { User } from '/imports/utils/User';
 import { ToastContainer, Flip } from 'react-toastify';
@@ -67,7 +68,9 @@ export const Dashboard = () => {
       <div className="p-4 lg:p-6 max-w-7xl mx-auto">
         {/* Intro message */}
         <div className="mb-8 bg-gradient-to-r text-[#328E6E] rounded-xl p-6 border-l-4 border-[#328E6E] shadow-lg">
-          <div className="flex items-center gap-3 mb-2 popInEffect">
+          <div
+            className={`flex items-center gap-3 mb-2 ${Meteor.isClient && 'popInEffect'}`}
+          >
             <span className="text-3xl">{greetingIcon}</span>
             <h1 className="text-2xl lg:text-4xl font-bold text-[#328E6E]">
               {greeting}, {user?.profile?.givenName}!

--- a/imports/ui/pages/Dashboard.jsx
+++ b/imports/ui/pages/Dashboard.jsx
@@ -1,7 +1,6 @@
 import React, { Suspense, useState, useEffect } from 'react';
 import { User } from '/imports/utils/User';
 import { ToastContainer, Flip } from 'react-toastify';
-import { SuspenseHydrated } from '../../utils/SuspenseHydrated';
 import { useSubscribe, useFind } from 'meteor/react-meteor-data/suspense';
 import { SkillTreeCollection } from '/imports/api/collections/SkillTree';
 import { Link } from 'react-router-dom';
@@ -9,8 +8,6 @@ import { HiOutlineChevronRight } from '@react-icons/all-files/hi/HiOutlineChevro
 
 // JSX UI
 import { DashboardSkillTrees } from '/imports/ui/layouts/DashboardSkillTrees';
-import { DashboardLoadingState } from '../components/Dashboard/LoadingState';
-import { GreetingLoadingState } from '../components/Dashboard/GreetingLoadingState';
 import {
   getGreetingIcon,
   getGreetingMessage
@@ -70,15 +67,12 @@ export const Dashboard = () => {
       <div className="p-4 lg:p-6 max-w-7xl mx-auto">
         {/* Intro message */}
         <div className="mb-8 bg-gradient-to-r text-[#328E6E] rounded-xl p-6 border-l-4 border-[#328E6E] shadow-lg">
-          {/* Opt out of SSR due to datetime mismatching on server and client hydration */}
-          <SuspenseHydrated fallback={<GreetingLoadingState />}>
-            <div className="flex items-center gap-3 mb-2 popInEffect">
-              <span className="text-3xl">{greetingIcon}</span>
-              <h1 className="text-2xl lg:text-4xl font-bold text-[#328E6E]">
-                {greeting}, {user?.profile?.givenName}!
-              </h1>
-            </div>
-          </SuspenseHydrated>
+          <div className="flex items-center gap-3 mb-2 popInEffect">
+            <span className="text-3xl">{greetingIcon}</span>
+            <h1 className="text-2xl lg:text-4xl font-bold text-[#328E6E]">
+              {greeting}, {user?.profile?.givenName}!
+            </h1>
+          </div>
           <p className="text-gray-600 ml-12">
             Ready to continue your learning journey?
           </p>
@@ -152,16 +146,13 @@ export const Dashboard = () => {
           )}
         </div>
         {/* My Skill Trees Section */}
-        {/* Opt out of SSR due to processing (sort) useFind data causing mismatch on hydration */}
         <div className="mb-8">
           {currentView === 'skillForest' && (
             <div className="mb-8 w-full">
-              <Suspense fallback={<DashboardLoadingState />}>
-                <DashboardSkillForest
-                  key={user._id}
-                  setCommunitiesCount={setCommunitiesCount}
-                />
-              </Suspense>
+              <DashboardSkillForest
+                key={user._id}
+                setCommunitiesCount={setCommunitiesCount}
+              />
             </div>
           )}
 

--- a/imports/ui/pages/Dashboard.jsx
+++ b/imports/ui/pages/Dashboard.jsx
@@ -1,7 +1,5 @@
-import { Meteor } from 'meteor/meteor';
-import React, { Suspense, useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import { User } from '/imports/utils/User';
-import { injectPreHydration } from '/imports/utils/PreHydration';
 
 import { ToastContainer, Flip } from 'react-toastify';
 import { useSubscribe, useFind } from 'meteor/react-meteor-data/suspense';

--- a/imports/ui/pages/Dashboard.jsx
+++ b/imports/ui/pages/Dashboard.jsx
@@ -1,6 +1,8 @@
 import { Meteor } from 'meteor/meteor';
 import React, { Suspense, useState, useEffect } from 'react';
 import { User } from '/imports/utils/User';
+import { injectPreHydration } from '/imports/utils/PreHydration';
+
 import { ToastContainer, Flip } from 'react-toastify';
 import { useSubscribe, useFind } from 'meteor/react-meteor-data/suspense';
 import { SkillTreeCollection } from '/imports/api/collections/SkillTree';
@@ -68,9 +70,7 @@ export const Dashboard = () => {
       <div className="p-4 lg:p-6 max-w-7xl mx-auto">
         {/* Intro message */}
         <div className="mb-8 bg-gradient-to-r text-[#328E6E] rounded-xl p-6 border-l-4 border-[#328E6E] shadow-lg">
-          <div
-            className={`flex items-center gap-3 mb-2 ${Meteor.isClient && 'popInEffect'}`}
-          >
+          <div className="flex items-center gap-3 mb-2 popInEffect">
             <span className="text-3xl">{greetingIcon}</span>
             <h1 className="text-2xl lg:text-4xl font-bold text-[#328E6E]">
               {greeting}, {user?.profile?.givenName}!

--- a/imports/ui/pages/GeneralForum.jsx
+++ b/imports/ui/pages/GeneralForum.jsx
@@ -3,6 +3,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { TopicList } from '../components/SkillTrees/GeneralForum/TopicListGeneralForum';
 import { NavigationMenu } from '../components/SkillTrees/NavigationMenu';
+import { toLocale } from '/imports/utils/Locale.jsx';
 
 export const GeneralForum = () => {
   const { skilltreeId } = useParams();
@@ -241,7 +242,7 @@ export const GeneralForum = () => {
                     <div className="text-gray-700">{msg.content}</div>
                     {msg.timestamp && (
                       <div className="text-xs text-gray-400 mt-1">
-                        {new Date(msg.timestamp).toLocaleString()}
+                        {toLocale(msg.timestamp)}
                       </div>
                     )}
                   </div>

--- a/imports/utils/Locale.jsx
+++ b/imports/utils/Locale.jsx
@@ -1,7 +1,19 @@
 import React from 'react';
 import { injectPreHydration } from '/imports/utils/PreHydration';
 
-// Helper function to format locale datetime as string which works with SSR via injectPreHydration utils to server render inline <script> that immediately sets on the client browser before hydration!
+/*
+Helper function to format locale datetime as string which works with SSR via injectPreHydration utils to server render inline <script> that immediately sets on the client browser before hydration!
+  Examples:
+    const dateObj = new Date('2036-08-12');
+    toLocale(dateObj); // 12/8/36, 12:00 am
+    toLocale(dateObj, 'DateTime'); // 12/8/36, 12:00 am
+    toLocale(dateObj, 'Date'); // 12/8/36
+    toLocale(dateObj, 'Time'); // 12:00 am
+    toLocale(dateObj, 'DateTimeShort'); // 12 Aug 2036, 12:00 am
+    toLocale(dateObj, 'DateTimeLong'); // 12 August 2036 at 12:00 am
+    toLocale(dateObj, 'DateTime', {}); // 12/08/2036, 12:00:00 am
+    toLocale(dateObj, 'DateTime', { month: 'short', hour: '2-digit' }, 'en-AU'); // Aug, 12 am
+*/
 export const toLocale = (
   dateObj, // Date Object
   format = 'DateTime', // 'DateTime', 'Date', 'Time', 'DateTimeShort', 'DateLong', 'DateTimeLong' -- Long formats dateStyle: 'long'

--- a/imports/utils/Locale.jsx
+++ b/imports/utils/Locale.jsx
@@ -1,8 +1,8 @@
 import { Meteor } from 'meteor/meteor';
 import React from 'react';
-import serialize from 'serialize-javascript';
+import { injectPreHydration } from '/imports/utils/PreHydration';
 
-// Helper function to format locale datetime as string which works with SSR via server rendering inline <script> to immediately set on the client browser before hydration!
+// Helper function to format locale datetime as string which works with SSR via injectPreHydration utils to server render inline <script> that immediately sets on the client browser before hydration!
 export const toLocale = (
   dateObj, // Date Object
   format = 'DateTime', // 'DateTime', 'Date', 'Time', 'DateTimeShort', 'DateLong', 'DateTimeLong' -- Long formats dateStyle: 'long'
@@ -34,34 +34,16 @@ export const toLocale = (
   })();
 
   if (['DateLong', 'DateTimeLong'].includes(format)) options.dateStyle = 'long'; // '...Long' formats dateStyle: 'long'
-  if (Meteor.isClient && !locales) locales = navigator.language; // Set default value to the user's locale on the client if not given
-  const localeString = () => dateObj[formatMethod](locales, options); // Convert to string by input arguments on the client
 
-  // Define client side inline script as literal string to inject before hydration, sanitised via serialize-javascript
-  const inlineScript = `
-    (function() {
-      const script = document.currentScript; // Reference to this <script> element on the DOM
-
-      // Pass arguments as serialized strings (sanitised) on server render for the client
-      const inlineDateObj = ${serialize(dateObj)};
-      const inlineFormatMethod = ${serialize(formatMethod)};
-      const inlineLocales = !${serialize(locales)} ? navigator.language : ${serialize(locales)};
-      const inlineOptions = ${serialize(options)};
-
-      // Set the localeString before <script> using the client's browser locale rather than the server's
-      script && (script.before(inlineDateObj[inlineFormatMethod](inlineLocales, inlineOptions)));
-      
-      // Remove itself <script> to clean up DOM and avoid hydration mismatch
-      script && script.remove();
-    })();
-  `;
-
-  return (
-    <>
-      {Meteor.isClient && localeString()}
-      {Meteor.isServer && (
-        <script dangerouslySetInnerHTML={{ __html: inlineScript }} />
-      )}
-    </>
+  // Use injectPreHydration utils to set locale string after server render but before hydration so that it matches to resolve timezone SSR mismatch
+  return injectPreHydration(
+    () =>
+      dateObj[formatMethod](!locales ? navigator.language : locales, options),
+    {
+      dateObj, // pass unscoped variables dependencies on function serialization
+      formatMethod,
+      locales,
+      options
+    }
   );
 };

--- a/imports/utils/Locale.jsx
+++ b/imports/utils/Locale.jsx
@@ -1,4 +1,3 @@
-import { Meteor } from 'meteor/meteor';
 import React from 'react';
 import { injectPreHydration } from '/imports/utils/PreHydration';
 

--- a/imports/utils/Locale.jsx
+++ b/imports/utils/Locale.jsx
@@ -1,0 +1,67 @@
+import { Meteor } from 'meteor/meteor';
+import React from 'react';
+import serialize from 'serialize-javascript';
+
+// Helper function to format locale datetime as string which works with SSR via server rendering inline <script> to immediately set on the client browser before hydration!
+export const toLocale = (
+  dateObj, // Date Object
+  format = 'DateTime', // 'DateTime', 'Date', 'Time', 'DateTimeShort', 'DateLong', 'DateTimeLong' -- Long formats dateStyle: 'long'
+  options = { dateStyle: 'short', timeStyle: 'short' }, // Format options, overridable but can just be omitted
+  locales = '' // User's locale, overridable but can just be omitted
+) => {
+  const formatMethod = (() => {
+    switch (format) {
+      case 'Date':
+      case 'DateLong':
+        if (options.timeStyle) delete options.timeStyle; // Remove timeStyle for 'Date' & 'DateLong'
+        return 'toLocaleDateString';
+      case 'Time':
+        if (options.dateStyle) delete options.dateStyle; // Remove dateStyle for 'Time'
+        return 'toLocaleTimeString';
+      default: // Default 'DateTime'
+        if (format == 'DateTimeShort') {
+          options = {
+            year: 'numeric',
+            month: 'short',
+            day: 'numeric',
+            hour: '2-digit',
+            minute: '2-digit'
+          };
+        }
+
+        return 'toLocaleString';
+    }
+  })();
+
+  if (['DateLong', 'DateTimeLong'].includes(format)) options.dateStyle = 'long'; // '...Long' formats dateStyle: 'long'
+  if (Meteor.isClient && !locales) locales = navigator.language; // Set default value to the user's locale on the client if not given
+  const localeString = () => dateObj[formatMethod](locales, options); // Convert to string by input arguments on the client
+
+  // Define client side inline script as literal string to inject before hydration, sanitised via serialize-javascript
+  const inlineScript = `
+    (function() {
+      const script = document.currentScript; // Reference to this <script> element on the DOM
+
+      // Pass arguments as serialized strings (sanitised) on server render for the client
+      const inlineDateObj = ${serialize(dateObj)};
+      const inlineFormatMethod = ${serialize(formatMethod)};
+      const inlineLocales = !${serialize(locales)} ? navigator.language : ${serialize(locales)};
+      const inlineOptions = ${serialize(options)};
+
+      // Set the localeString before <script> using the client's browser locale rather than the server's
+      script && (script.before(inlineDateObj[inlineFormatMethod](inlineLocales, inlineOptions)));
+      
+      // Remove itself <script> to clean up DOM and avoid hydration mismatch
+      script && script.remove();
+    })();
+  `;
+
+  return (
+    <>
+      {Meteor.isClient && localeString()}
+      {Meteor.isServer && (
+        <script dangerouslySetInnerHTML={{ __html: inlineScript }} />
+      )}
+    </>
+  );
+};

--- a/imports/utils/PreHydration.jsx
+++ b/imports/utils/PreHydration.jsx
@@ -1,0 +1,45 @@
+import { Meteor } from 'meteor/meteor';
+import React from 'react';
+import serialize from 'serialize-javascript';
+
+/*
+  Helper function to inject content from an input function as setContentFn on the client before hydration to resolve mismatches with SSR edge cases
+  It delays setContentFn on the server render by serializing the function as an inline <script> so that it is executed on the client browser immediately before hydration
+  to match with the client's setContentFn (without <script>) on hydration. Sanitised via serialize-javascript to reduce XSS potential on setContentFn's arguments
+  dependencies is an object of all varName: varValue used to substitute each varName occurrence in setContentFn with its varValue in the inline script since serializing a function loses its original scope values
+*/
+export const injectPreHydration = (
+  setContentFn, // function that sets the content before hydration to be serialized within inline script and when hydrated to match the same
+  dependencies = {}, // object of {varName: varValue, ...} for unscoped variables dependencies on function serialization variable value substitution
+  wrapSpan = false // whether the content should be wrapped with <span>...</span>, set as true to fix DOM structure hydration mismatch by ensuring both results are within same structure
+) => {
+  const injection = () => {
+    if (Meteor.isClient) return setContentFn(); // Client on hydration simply returns setContentFn result, the rest is for server render only to serialize it as inline script
+
+    // Serialize setContentFn body with all dependent (unscoped) variables substituted by its (sanitised) value in place so that it uses the value rather than its name in the inline script
+    const setContentFnSerializedBody = Object.keys(dependencies).reduce(
+      (body, varName) =>
+        body.replace(varName, serialize(dependencies[varName])), // Each occurrence of dependent variables gets replaced with its value (serialized) since it's unscoped
+      serialize(setContentFn).replace(/^function(\({|[^{])*|^.*?=>/s, '') // Regex pattern: strips function signature to get its body content only so that it works with different types (arrow etc).
+    );
+
+    // Inline script as literal string to inject and execute setContentFn in <script> on the client before hydration, sanitised via serialize-javascript
+    const inlineScript = `
+      (function() {
+        const script = document.currentScript; // Reference to this <script> element on the DOM
+        
+        // Set content before <script> by running the setContentFn() in the client's browser rather than the server render
+        script && (script.before(
+          (() => ${setContentFnSerializedBody})()
+        ));
+        
+        // Remove itself <script> to clean up DOM and avoid mismatch on hydration (as it won't have the <script>) 
+        script && script.remove();
+      })();
+    `;
+
+    return <script dangerouslySetInnerHTML={{ __html: inlineScript }} />; // Server render the script where it will execute setContentFn on the client before hydration to match client's setContentFn
+  };
+
+  return wrapSpan ? <span>{injection()}</span> : injection(); // return content of injection() either with wrapSpan or not
+};

--- a/imports/utils/User.js
+++ b/imports/utils/User.js
@@ -5,19 +5,23 @@ import { useFind } from 'meteor/react-meteor-data/suspense';
 // AuthContext
 import { AuthContext } from '/imports/utils/contexts/AuthContext';
 
-// Helper function that takes in a list of fields to return for the logged in user
-export const User = (fields = [], options = {}) => {
-  const projection = {
+// Helper function that takes in a list of fields, options and dependencies to return for the loggedIn user
+export const User = (fields = [], options = {}, dependencies = []) => {
+  const fieldsOption = {
     fields: Object.fromEntries(fields.map(field => [field, 1]))
   };
   const userId = useContext(AuthContext); // Reactive when value changes
 
   return (
-    useFind(Meteor.users, [{ _id: { $eq: userId } }, projection, options])[0] ??
-    undefined
+    useFind(Meteor.users, [
+      { _id: { $eq: userId } },
+      { ...options, ...fieldsOption }, // fields argument overrides any fields in option (duplicate)
+      dependencies
+    ])[0] ?? undefined
   );
 
+  // Old Meteor.user() method breaks SSR
   // return Meteor.isClient
-  //   ? Meteor.user(projection) // user for client
-  //   : Meteor.userAsync(projection); // userAsync for server
+  //   ? Meteor.user({ ...options, ...fieldsOption }) // user for client
+  //   : Meteor.userAsync({ ...options, ...fieldsOption }); // userAsync for server
 };

--- a/imports/utils/providers/AuthProvider.jsx
+++ b/imports/utils/providers/AuthProvider.jsx
@@ -1,12 +1,17 @@
 import { Meteor } from 'meteor/meteor';
 import React from 'react';
-import { useTracker } from 'meteor/react-meteor-data';
+import { useTracker } from 'meteor/react-meteor-data/suspense';
+//import { Tracker } from 'meteor/tracker';
 
 // Import Context
 import { AuthContext } from '/imports/utils/contexts/AuthContext';
 
 // Create Provider
 export const AuthProvider = ({ children }) => {
-  const userId = useTracker(() => Meteor.userId());
+  // const userId = useTracker(
+  //   'AuthContextProvider',
+  //   async c => await Tracker.withComputation(c, () => Meteor.userId())
+  // );
+  const userId = useTracker('AuthContextProvider', async () => Meteor.userId());
   return <AuthContext.Provider value={userId}>{children}</AuthContext.Provider>;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "react-router-dom": "^6.30.1",
         "react-spinners": "^0.17.0",
         "react-toastify": "^11.0.5",
+        "serialize-javascript": "^7.0.0",
         "tailwindcss": "^4.1.7",
         "use-immer": "^0.11.0"
       },
@@ -7495,6 +7496,15 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/serialize-javascript": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.0.tgz",
+      "integrity": "sha512-pgLqXJrPEahCSuSLFvmBbIi6C769CQkpG509G8lwnaltznys3QxinnJE71cr78TOr6OPi+boskt4NvRbhfgFrA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/set-function-length": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "react-router-dom": "^6.30.1",
     "react-spinners": "^0.17.0",
     "react-toastify": "^11.0.5",
+    "serialize-javascript": "^7.0.0",
     "tailwindcss": "^4.1.7",
     "use-immer": "^0.11.0"
   },


### PR DESCRIPTION
# Summary
> [!NOTE]
> Added new Utils:
> - Custom `injectPreHydration()` helper function to inject content from an input function (as `setContentFn`) on the client for the server render before hydration to resolve mismatches on client with SSR edge cases such as datetime locale differing on the server and client.
> - Custom `toLocale()` helper function to convert datetime to locale strings that works with SSR as the server render would normally use the server's locale and datetime that may be different to the client which will cause a hydration mismatch.
>
> There are 3 possible edge cases known with SSR on hydration mismatches which all can now be resolved or selectively opt-out of SSR as the last resort if the suggested resolutions does not work to workaround the issue:
> - Non useFind hook usage such as meteor methods calls or useTracker to fetch data from the DB may not server render properly and mismatch. *All such usage* **should ideally be transitioned to useFind if possible as the resolution** *otherwise may opt-out of SSR as the last resort stopgap.*
>  - Displaying a list of fetch result data (map IDs) from useFind may mismatch between the server (reversed order) and client (natural order). **The resolution is to explicitly sort in the useFind options via `useFind(COLLECTION, { MongoSelector... }, { options..., sort: { _id: 1 } })`** *otherwise opt-out of SSR as the last resort if it does not resolve the issue.*
>  - Datetime locale mismatches on server and client due to timezone differences. *All such usage* **should utilise `toLocale()` utils that uses the custom `injectPreHydration(...)` under the hood to resolve the issue**.
>
> For any future edge cases, the new `injectPreHydration()` utils can be used to have the server render set the content from a function executed on the client browser before hydration instead of the server. 

- switched AuthProvider's useTracker to suspense version by changing into async to resolve previous freeze/errors issue
-  moved utils/User projection as fieldsOption into useFind's 2nd argument as { ...options, ...fieldsOption } and added dependencies parameter
- refactored users publication to remove unnecessary 'user' & 'usernames' publishing
-  added sort option in useFind explicitly to resolve SSR hydration mismatch issue for DashboardSkillTrees and updated docs on SuspenseHydrated (SSR Opt-Out) section
- added serialize-javascript package and toLocale() utils to format locale datetime as string which works with SSR via server rendering inline <script> to immediately set on the client browser before hydration!
- refactored toLocaleString() -> toLocale() utils
- refactored getGreeting to reduce code repetition
- refactored Greeting to use inline Script to work with SSR
- add injectPreHydration utils to inject content from an input function as setContentFn on the client before hydration to resolve mismatches with SSR edge cases
- refactored Locale & Greeting to use injectPreHydration utils
- updated docs on SSR

# Related Issues:

_Fixes #131_
> Certain subscribed data mismatching on page load/refresh SSR can be now opt-out via `<SuspenseHydrated />` as a workaround. Also adds popInEffect for the greeting and datetime in proofLists to smooth out the fallback transition.
> 
> There are 3 edge cases with SSR so far:
>
> <details>
> <summary>⋯</summary>
>
> - Non useFind (meteor methods call) to fetch data from the DB does not server render properly. _All such usage should be transitioned to useFind if possible._
> - Modified data from useFind such as sorting the array of IDs will result in a mismatch between the server (non modified) and client (modified on hydration, sorted etc). Sorting DB data should be done via https://www.mongodb.com/docs/manual/reference/operator/aggregation/sort/ if possible. This edge case is currently being investigated where it's likely that useTracker/suspense has to be used but currently the hook does not seem to play nice with suspense (freezes/errors).
> - Datetime mismatches on server and client due to timezone differences. There might be a hacky way for a workaround that involves in loading <Script></Script> to set the date to local timezone before hydration but may be very tricky to do. Will be investigated later.
> </details>

# Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change involves a documentation update

# How Has This Been Tested?
- [x] Refreshing dashboard page correctly server renders greeting and skilltree list order no longer mismatches
- [x] Refreshing climbing proofs correctly server renders all datetime

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, specifically in difficult-to-understand code areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have conducted tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been carefully merged and published in downstream modules

