### PR TITLE
fix: sample account subscribed communities shows basketball

### DIFF
--- a/imports/api/publications/Users.js
+++ b/imports/api/publications/Users.js
@@ -272,6 +272,15 @@ Meteor.startup(async () => {
   // There is a hardcoded subscription object for sampleId and basketball, so we need to run this method to ensure consistency with the subscribers list.
   await Meteor.callAsync('skilltrees.subscribeUser', 'basketball', sampleId);
 
+  // Need to add it so subscribers community
+  // There is a method called "updateSubscribedCommunities", however this requires the user to be logged in. In this case, we are
+  // calling this during meteor startup so no user is logged in. We will call the update directly for the sake of the sample account
+  await Meteor.users.updateAsync(
+    { _id: sampleId },
+    { $addToSet: { 'profile.subscribedCommunities': 'basketball' } },
+    { validate: false }
+  );
+
   //Sample Dummy skilltree progress
   for (const progressTree of dummyProgressTree) {
     var copyProgressTree1 = { ...progressTree };


### PR DESCRIPTION
# Summary

- Fixed issue where basketball community does not show up in the dashboard even though it is subscribed. 
- Since this is a sample account, we have to add the basketball community to the sample user's subscribed community set


# Related Issues:

_NONE_



# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] This change involves a documentation update

# How Has This Been Tested?

- [ ] Log into sample account and observe dashboard 


# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, specifically in difficult-to-understand code areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have conducted tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been carefully merged and published in downstream modules

