### PR TITLE
St 325 end events

### DIFF
--- a/imports/api/methods/Events.js
+++ b/imports/api/methods/Events.js
@@ -29,7 +29,7 @@ Meteor.methods({
    * @param {Object} event event object with data
    * @returns _id of the newly created event
    */
-  async createEvent(event) {
+  async createEvent(event, userId) {
     // Check if the skilltree exists
     const skilltree = await SkillTreeCollection.findOneAsync({
       _id: event.skilltreeId
@@ -39,7 +39,6 @@ Meteor.methods({
     }
 
     // Check current user is admin
-    const userId = this.userId;
     const skilltreeId = event.skilltreeId;
 
     const subscription = await SubscriptionsCollection.findOneAsync({
@@ -50,7 +49,6 @@ Meteor.methods({
 
     const userRoles = subscription?.roles || [];
     const isAdmin = userRoles.includes('admin');
-    console.log('isAdmin:', isAdmin);
     if (!isAdmin)
       throw new Meteor.Error('User must be an admin to create event.');
 
@@ -200,11 +198,13 @@ Meteor.methods({
   /**
    * Stops event and awards trophies if the event is ranked
    * Currently takes maxTrophies and gives 1 less to each lower position (min 1)
+   * NOTE: to avoid breaking the tests, need to receive userId as a parameter
+   * rather than running Meteor.userId() on the server.
    *
    * @param {String} eventId _id of event
    * @returns number of documents affected
    */
-  async stopEvent(eventId) {
+  async stopEvent(eventId, userId) {
     check(eventId, String);
 
     // check event exists
@@ -214,7 +214,6 @@ Meteor.methods({
     }
 
     // Check current user is admin
-    const userId = this.userId;
     const skilltreeId = eventObject.skilltreeId;
 
     const subscription = await SubscriptionsCollection.findOneAsync({

--- a/imports/api/methods/Events.js
+++ b/imports/api/methods/Events.js
@@ -38,6 +38,22 @@ Meteor.methods({
       throw new Meteor.Error('skilltree-not-found', 'Skilltree does not exist');
     }
 
+    // Check current user is admin
+    const userId = this.userId;
+    const skilltreeId = event.skilltreeId;
+
+    const subscription = await SubscriptionsCollection.findOneAsync({
+      userId: userId,
+      skilltreeId: skilltreeId,
+      active: true
+    });
+
+    const userRoles = subscription?.roles || [];
+    const isAdmin = userRoles.includes('admin');
+    console.log('isAdmin:', isAdmin);
+    if (!isAdmin)
+      throw new Meteor.Error('User must be an admin to create event.');
+
     // Check if there is already an active event for this skilltree
     const existingEvent = await EventCollection.findOneAsync({
       skilltreeId: event.skilltreeId,
@@ -170,8 +186,8 @@ Meteor.methods({
     check(eventId, String);
 
     // check event exists
-    const eventExists = await EventCollection.findOneAsync({ _id: eventId });
-    if (!eventExists) {
+    const eventObject = await EventCollection.findOneAsync({ _id: eventId });
+    if (!eventObject) {
       throw new Meteor.Error('event-not-found', 'Event does not exist');
     }
 

--- a/imports/api/methods/Events.js
+++ b/imports/api/methods/Events.js
@@ -1,9 +1,9 @@
-import { Meteor } from 'meteor/meteor';
-import { EventCollection } from '/imports/api/collections/Events';
-import { ProofCollection } from '../collections/Proof';
-import { SubscriptionsCollection } from '../collections/Subscriptions';
-import { SkillTreeCollection } from '../collections/SkillTree';
 import { check } from 'meteor/check';
+import { Meteor } from 'meteor/meteor';
+import { ProofCollection } from '../collections/Proof';
+import { SkillTreeCollection } from '../collections/SkillTree';
+import { SubscriptionsCollection } from '../collections/Subscriptions';
+import { EventCollection } from '/imports/api/collections/Events';
 
 Meteor.methods({
   /**
@@ -196,6 +196,20 @@ Meteor.methods({
     if (!eventObject) {
       throw new Meteor.Error('event-not-found', 'Event does not exist');
     }
+
+    // Check current user is admin
+    const userId = this.userId;
+    const skilltreeId = eventObject.skilltreeId;
+
+    const subscription = await SubscriptionsCollection.findOneAsync({
+      userId: userId,
+      skilltreeId: skilltreeId,
+      active: true
+    });
+
+    const userRoles = subscription?.roles || [];
+    const isAdmin = userRoles.includes('admin');
+    if (!isAdmin) throw new Meteor.Error('User must be an admin to end event.');
 
     const res = await EventCollection.updateAsync(
       { _id: eventId },

--- a/imports/api/publications/Users.js
+++ b/imports/api/publications/Users.js
@@ -261,8 +261,6 @@ Meteor.startup(async () => {
     }
   });
 
-  await Meteor.callAsync('skilltrees.subscribeUser', 'basketball', sampleId);
-
   await Meteor.callAsync(
     'skilltrees.subscribeUser',
     'basketball',

--- a/imports/ui/components/RankedEvents/EndEventModal.jsx
+++ b/imports/ui/components/RankedEvents/EndEventModal.jsx
@@ -2,9 +2,11 @@ import { Meteor } from 'meteor/meteor';
 import React from 'react';
 
 export const EndEventModal = ({ isOpen, onClose, eventId }) => {
+  const userId = Meteor.userId() || '';
+
   const handleEndEvent = async () => {
     try {
-      await Meteor.callAsync('stopEvent', eventId);
+      await Meteor.callAsync('stopEvent', eventId, userId);
       onClose();
     } catch (err) {
       console.error(err);

--- a/imports/ui/components/RankedEvents/EndEventModal.jsx
+++ b/imports/ui/components/RankedEvents/EndEventModal.jsx
@@ -1,0 +1,39 @@
+import { Meteor } from 'meteor/meteor';
+import React from 'react';
+
+export const EndEventModal = ({ isOpen, onClose, eventId }) => {
+  const handleEndEvent = async () => {
+    try {
+      await Meteor.callAsync('stopEvent', eventId);
+      onClose();
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+      <div className="bg-white rounded-xl p-6 w-full max-w-md shadow-lg">
+        <h2 className="text-xl font-bold mb-4">
+          Are you sure you want to end this event?
+        </h2>
+        <div className="flex justify-end gap-2 mt-4">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 rounded bg-gray-300 hover:bg-gray-400"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleEndEvent}
+            className="px-4 py-2 rounded bg-[#328E6E] text-white hover:bg-[#2a7d60]"
+          >
+            End Event
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/imports/ui/components/RankedEvents/NewEventForm.jsx
+++ b/imports/ui/components/RankedEvents/NewEventForm.jsx
@@ -27,11 +27,15 @@ export const NewEventModal = ({ isOpen, onClose, skilltreeId }) => {
         throw new Error('End date must be after start date.');
       }
 
-      await Meteor.callAsync('createEvent', {
-        ...formData,
-        skilltreeId,
-        createdAt: new Date()
-      });
+      await Meteor.callAsync(
+        'createEvent',
+        {
+          ...formData,
+          skilltreeId,
+          createdAt: new Date()
+        },
+        Meteor.userId()
+      );
 
       onClose();
     } catch (err) {

--- a/imports/ui/pages/RankedEvent.jsx
+++ b/imports/ui/pages/RankedEvent.jsx
@@ -8,6 +8,7 @@ import { EventCard } from '../components/RankedEvents/EventCard';
 import { EventInfoModal } from '../components/RankedEvents/EventInfoModal';
 import { NavigationMenu } from '../components/SkillTrees/NavigationMenu';
 import { NewEventModal } from '../components/RankedEvents/NewEventForm';
+import { EndEventModal } from '../components/RankedEvents/EndEventModal';
 import { JoinEventButton } from '../components/SkillTrees/Events/JoinEventButton';
 import { ProofUploadButton } from '../components/SkillTrees/Skill/ProofUploadButton';
 import { EventLeaderboardModal } from '../components/RankedEvents/EventLeaderboardModal';
@@ -20,6 +21,7 @@ export const RankedEvent = () => {
   const { skilltreeId } = useParams();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
+  const [isEndModalOpen, setIsEndModalOpen] = useState(false);
 
   useSubscribe('skilltrees');
   useSubscribe('events');
@@ -211,6 +213,23 @@ export const RankedEvent = () => {
             >
               + Add Event
             </button>
+            {/* End Event Button (Admin Only, Greyed Out for Non-Admins) */}
+            <button
+              onClick={() => {
+                if (userRoles.includes('admin')) {
+                  setIsEndModalOpen(true);
+                } else {
+                  alert('Only admins are allowed to end ranked events');
+                }
+              }}
+              className={`w-full sm:w-auto font-semibold py-2 px-4 rounded-lg shadow transition-colors ${
+                userRoles.includes('admin')
+                  ? 'bg-[#328E6E] text-white hover:bg-[#2a7d60]'
+                  : 'bg-gray-400 text-gray-200 cursor-not-allowed'
+              }`}
+            >
+              End Event
+            </button>
           </div>
         </div>
 
@@ -233,6 +252,11 @@ export const RankedEvent = () => {
         isOpen={isAddModalOpen}
         onClose={() => setIsAddModalOpen(false)}
         skilltreeId={skilltreeId}
+      />
+      <EndEventModal
+        isOpen={isEndModalOpen}
+        onClose={() => setIsEndModalOpen(false)}
+        eventId={eventId}
       />
     </>
   );

--- a/imports/ui/pages/RankedEvent.jsx
+++ b/imports/ui/pages/RankedEvent.jsx
@@ -1,17 +1,17 @@
 import { Meteor } from 'meteor/meteor';
+import { useFind, useSubscribe } from 'meteor/react-meteor-data/suspense';
 import React, { Suspense, useState } from 'react';
 import { Helmet } from 'react-helmet';
-import { useFind, useSubscribe } from 'meteor/react-meteor-data/suspense';
 import { useParams } from 'react-router-dom';
 
+import { EndEventModal } from '../components/RankedEvents/EndEventModal';
 import { EventCard } from '../components/RankedEvents/EventCard';
 import { EventInfoModal } from '../components/RankedEvents/EventInfoModal';
-import { NavigationMenu } from '../components/SkillTrees/NavigationMenu';
-import { NewEventModal } from '../components/RankedEvents/NewEventForm';
-import { EndEventModal } from '../components/RankedEvents/EndEventModal';
-import { JoinEventButton } from '../components/SkillTrees/Events/JoinEventButton';
-import { ProofUploadButton } from '../components/SkillTrees/Skill/ProofUploadButton';
 import { EventLeaderboardModal } from '../components/RankedEvents/EventLeaderboardModal';
+import { NewEventModal } from '../components/RankedEvents/NewEventForm';
+import { JoinEventButton } from '../components/SkillTrees/Events/JoinEventButton';
+import { NavigationMenu } from '../components/SkillTrees/NavigationMenu';
+import { ProofUploadButton } from '../components/SkillTrees/Skill/ProofUploadButton';
 
 import { EventCollection } from '/imports/api/collections/Events';
 import { SkillTreeCollection } from '/imports/api/collections/SkillTree';

--- a/tests/eventsMethods.js
+++ b/tests/eventsMethods.js
@@ -5,6 +5,7 @@ import '/imports/api/methods/Events';
 import { EventCollection } from '/imports/api/collections/Events';
 import { ProofCollection } from '/imports/api/collections/Proof';
 import { SkillTreeCollection } from '/imports/api/collections/SkillTree';
+import { SubscriptionsCollection } from '/imports/api/collections/Subscriptions';
 
 const TEST_ID_1 = 'abcd1234';
 const TEST_ID_2 = '1234abcd';
@@ -36,28 +37,39 @@ const skillTree = {
   image:
     'https://media.istockphoto.com/id/1636022764/photo/basketball-ball.jpg?s=612x612&w=0&k=20&c=NVi1V5dCAZKUHdrhnRq-G5t8XSvZE1YXvgw8NxX3N0I=',
   description: 'Learn dribbling to shooting.',
-  termsAndConditions: 'This SkillTree is intended for sports training purposes.',
+  termsAndConditions:
+    'This SkillTree is intended for sports training purposes.',
   tags: ['basketball', 'sports', 'ball'],
   skillNodes: [],
   skillEdges: [],
-  admins: ['basketballpro'],
+  admins: ['basketballpro', 'test'],
   subscribers: ['playerA', 'playerB']
 };
 
-const insertSkillTree = async st => Meteor.callAsync('skilltrees.insertAsync', st);
+const insertSkillTree = async st =>
+  Meteor.callAsync('skilltrees.insertAsync', st);
 const getEvent = async eventId => Meteor.callAsync('getEvent', eventId);
 
 before(async function () {
   testUser = await Accounts.createUserAsync({ username: 'Test' });
   testProof.user = testUser;
+  await SubscriptionsCollection.insertAsync({
+    userId: testUser,
+    skilltreeId: SKILLTREE_ID,
+    skillNodes: {},
+    skillEdges: {},
+    totalXp: 0,
+    roles: ['admin'],
+    numComments: 0,
+    active: true
+  });
 });
 
 describe('Events Methods', function () {
-
   describe('createEvent', function () {
     it('creates an event in the Skilltree', async function () {
-      await insertSkillTree(skillTree);
-      const res = await Meteor.callAsync('createEvent', testEvent);
+      await insertSkillTree(skillTree); // Need a way to bypass admin check when testing
+      const res = await Meteor.callAsync('createEvent', testEvent, testUser);
       assert.strictEqual(res, TEST_ID_1);
     });
   });
@@ -79,7 +91,11 @@ describe('Events Methods', function () {
 
   describe('addUser', function () {
     it('adds a user to an event', async function () {
-      await Meteor.callAsync('skilltrees.subscribeUser', SKILLTREE_ID, testUser);
+      await Meteor.callAsync(
+        'skilltrees.subscribeUser',
+        SKILLTREE_ID,
+        testUser
+      );
       const res = await Meteor.callAsync('addUser', testUser, TEST_ID_1);
       assert.strictEqual(res, 1);
 
@@ -110,7 +126,7 @@ describe('Events Methods', function () {
 
   describe('stopEvent', function () {
     it('stops the event', async function () {
-      const res = await Meteor.callAsync('stopEvent', TEST_ID_1);
+      const res = await Meteor.callAsync('stopEvent', TEST_ID_1, testUser);
       assert.strictEqual(res, 1);
 
       const eventObj = await getEvent(TEST_ID_1);
@@ -121,7 +137,11 @@ describe('Events Methods', function () {
   describe('addProof', function () {
     it('adds proof to event', async function () {
       // Ensure user is subscribed and added
-      await Meteor.callAsync('skilltrees.subscribeUser', SKILLTREE_ID, testUser);
+      await Meteor.callAsync(
+        'skilltrees.subscribeUser',
+        SKILLTREE_ID,
+        testUser
+      );
       await Meteor.callAsync('addUser', testUser, TEST_ID_1);
 
       const resProof = await Meteor.callAsync('addProof', testProof, TEST_ID_1);
@@ -132,7 +152,6 @@ describe('Events Methods', function () {
       assert.strictEqual(proof.user, testUser);
     });
   });
-
 });
 
 after(async function () {


### PR DESCRIPTION
NOTE: In the event of having to make quick fixes or under limited time, just provide a quick summary. Delete the rest.

# Summary

Please include a summary of the changes (dot points)
- Added the ability for admins to end the active event by hitting a button, including client- and server-side validation ensuring the user is an admin. 
- Added server-side validation for ensuring user is admin when they start the event.

# Related Issues:

_Fixes #(Issue Number)_
ST-325


# Type of change

Please delete options that are not relevant.

- [X] Breaking change (fix or feature that would cause existing functionality not to work as expected)

# How Has This Been Tested?
Please describe in detail how you tested your changes (i.e., User Testing, Unit Testing)
Provide instructions so we can reproduce.

- [X] Manually trying to create/end an event in a skilltree where you are an admin (Basketball) and seeing the event be successfully created/ended
- [X] Manually trying to create/end an event in a skilltree where you are not an admin (Tennis) and being unable to do so


# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, specifically in difficult-to-understand code areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have conducted tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been carefully merged and published in downstream modules

