### PR TITLE
Fix Button positioning on modal to not hang

### DIFF
--- a/imports/ui/components/SkillTrees/Leaderboard/CommunityLeaderboardModal.jsx
+++ b/imports/ui/components/SkillTrees/Leaderboard/CommunityLeaderboardModal.jsx
@@ -90,12 +90,12 @@ export const CommunityLeaderboardModal = () => {
           ></CommunityLeaderboardList>
         </div>
       </ModalBody>
-      <ModalFooter>
+      <ModalFooter className="flex justify-start px-6 py-4 border-t border-gray-200 rounded-b-lg">
         <Button
           color="green"
           onClick={closeModal}
           pill
-          className="cursor-pointer position-relative text-lg font-bold mt-2 text-white leading-none !font-sans flex items-center gap-3 px-6 py-3 bg-[#328E6E] rounded-[22px] transition-all duration-200 hover:bg-[#2a7a5e] focus:outline-none focus:ring-0"
+          className="text-lg font-bold text-white leading-none !font-sans flex items-center gap-3 px-6 py-3 bg-[#328E6E] rounded-[22px] transition-all duration-200 hover:bg-[#2a7a5e] focus:outline-none focus:ring-0"
         >
           Close
         </Button>


### PR DESCRIPTION
NOTE: In the event of having to make quick fixes or under limited time, just provide a quick summary. Delete the rest.

# Summary
- Fixed "Close" button to not hang off modal in the leaderboard modal


# Type of change

Please delete options that are not relevant.

- [ ] Bug fix

# How Has This Been Tested?
User Testing

# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, specifically in difficult-to-understand code areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have conducted tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been carefully merged and published in downstream modules

